### PR TITLE
Adding main field pointing to jsoneditor.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "jsoneditor",
+    "main": "jsoneditor.js",
     "version": "2.3.0",
     "description": "A web-based tool to view, edit and format JSON",
     "tags": [


### PR DESCRIPTION
Without this `require('jsoneditor')` fails with the following error:

```
Error: Cannot find module 'jsoneditor'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/thlorenz/dev/projects/level-json-edit/example/main.js:3:18)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```
