### PR TITLE
Update jsoneditor.js

### DIFF
--- a/jsoneditor.js
+++ b/jsoneditor.js
@@ -6260,5 +6260,5 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }
-/******/ ])
-})
+/******/ ]);
+});


### PR DESCRIPTION
the lack of semicolons at the end of the file is causing breakage when bower components get concatted together if the next component starts with a ( such as with a self calling anonymous function, which is a common patter for libs.
