### PR TITLE
Allow editable option also in 'form' mode

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -41,7 +41,7 @@ define(['./ContextMenu', './appendNodeFactory', './util'], function (ContextMenu
       this.editable.field = this.editor.options.mode === 'tree';
       this.editable.value = this.editor.options.mode !== 'view';
 
-      if (this.editor.options.mode === 'tree' && (typeof this.editor.options.editable === 'function')) {
+      if ((this.editor.options.mode === 'tree' || this.editor.options.mode === 'form') && (typeof this.editor.options.editable === 'function')) {
         var editable = this.editor.options.editable({
           field: this.field,
           value: this.value,


### PR DESCRIPTION
Currently in 'tree' mode the structure can be changed, but editable option works and in 'form' mode the structure is read-only, but editable option is omitted.

I needed a mode, where the structure is read-only and I could also programmatically decide is the property or value editable.
