### PR TITLE
Allow editable option also in 'form' mode

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,7 +18,7 @@ Constructs a new JSONEditor.
   - `{function} change`  
     Set a callback method triggered when the contents of the JSONEditor change. Called without parameters.
   - `{function} editable`  
-    Set a callback method to determine whether individual nodes are editable or read-only. Only applicable when option `mode` is `tree`. The callback is invoked as `editable(node)`, where `node` is an object `{field: string, value: string, path: string[]}`. The function must either return a boolean value to set both the nodes field and value editable or read-only, or return an object `{field: boolean, value: boolean}`.
+    Set a callback method to determine whether individual nodes are editable or read-only. Only applicable when option `mode` is `tree` or `form`. The callback is invoked as `editable(node)`, where `node` is an object `{field: string, value: string, path: string[]}`. The function must either return a boolean value to set both the nodes field and value editable or read-only, or return an object `{field: boolean, value: boolean}`.
   - `{function} error`  
     Set a callback method triggered when an error occurs. Invoked with the error as first argument. The callback is only invoked
     for errors triggered by a users action.

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -41,7 +41,7 @@ define(['./ContextMenu', './appendNodeFactory', './util'], function (ContextMenu
       this.editable.field = this.editor.options.mode === 'tree';
       this.editable.value = this.editor.options.mode !== 'view';
 
-      if (this.editor.options.mode === 'tree' && (typeof this.editor.options.editable === 'function')) {
+      if ((this.editor.options.mode === 'tree' || this.editor.options.mode === 'tree') && (typeof this.editor.options.editable === 'function')) {
         var editable = this.editor.options.editable({
           field: this.field,
           value: this.value,

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -41,7 +41,7 @@ define(['./ContextMenu', './appendNodeFactory', './util'], function (ContextMenu
       this.editable.field = this.editor.options.mode === 'tree';
       this.editable.value = this.editor.options.mode !== 'view';
 
-      if ((this.editor.options.mode === 'tree' || this.editor.options.mode === 'tree') && (typeof this.editor.options.editable === 'function')) {
+      if ((this.editor.options.mode === 'tree' || this.editor.options.mode === 'form') && (typeof this.editor.options.editable === 'function')) {
         var editable = this.editor.options.editable({
           field: this.field,
           value: this.value,


### PR DESCRIPTION
Currently in `tree` mode the structure can be changed, but editable option works and in `form` mode the structure is read-only, but editable option is omitted.

I needed a mode, where the structure is read-only and I could also programmatically decide is the property or value editable.
