### PR TITLE
Included jsoneditor.css as a Main Component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,10 @@
     "type": "git",
     "url": "https://github.com/josdejong/jsoneditor.git"
   },
-  "main": "jsoneditor.min.js",
+  "main": [
+    "jsoneditor.min.js", 
+    "jsoneditor.css"
+  ],
   "bugs": "https://github.com/josdejong/jsoneditor/issues",
   "ignore": [
     "app",


### PR DESCRIPTION
Added the css file to bower so that the css will be identified as a main component used. Making this change allows gulp to identify the css and inject it into the project automatically at build time.

Executing the following shell commands:

``` shell
    yo gulp-angular
    bower install jsoneditor --save
    gulp build
```

will result in the index.html automatically being injected as seen below:

``` html
    <!-- bower:css -->
    <link rel="stylesheet" href="../bower_components/jsoneditor/jsoneditor.css" />
    <!-- endbower -->
    <!-- endbuild -->

    <!-- build:js scripts/vendor.js -->
    <!-- bower:js -->
    <script src="../bower_components/jsoneditor/jsoneditor.min.js"></script>
    <!-- endbower -->
    <!-- endbuild -->
```
