### PR TITLE
Support for custom themes.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,8 @@ Constructs a new JSONEditor.
     Enables a search box in the upper right corner of the JSONEditor. True by default. Only applicable when `mode` is 'tree', 'view', or 'form'.
   - `{Number} indentation`  
     Number of indentation spaces. 2 by default. Only applicable when `mode` is 'code' or 'text'.
+  - `{String} theme`  
+    Set the Ace editor theme, uses included 'ace/theme/jsoneditor' by default. Please note that only the default theme is included with jsoneditor, so if you specify another one you need to make sure it is loaded.
 
 - `{JSON} json`  
   Initial JSON data to be loaded into the JSONEditor. Alternatively, the method `JSONEditor.set(json)` can be used to load JSON data into the editor.

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -44,6 +44,7 @@ textmode.create = function (container, options) {
           'Falling back to plain text editor');
     }
   }
+  this.theme = options.theme || 'ace/theme/jsoneditor';
 
   var me = this;
   this.container = container;
@@ -117,7 +118,7 @@ textmode.create = function (container, options) {
     this.content.appendChild(this.editorDom);
 
     var editor = ace.edit(this.editorDom);
-    editor.setTheme('ace/theme/jsoneditor');
+    editor.setTheme(this.theme);
     editor.setShowPrintMargin(false);
     editor.setFontSize(13);
     editor.getSession().setMode('ace/mode/json');


### PR DESCRIPTION
This PR adds support for specifying custom themes in JSONEditor options when using the code editor.

Since only the 'jsoneditor' theme is included by default, using this requires you to include the theme yourself _outside_ of jsoneditor. Here's an example using browserify:

```javascript
require('brace');  // required for the next line to work
require('brace/theme/monokai');  // load the theme

var JSONEditor = require('jsoneditor');
var editor = new JSONEditor(el, { mode: 'code', theme: 'ace/theme/monokai' });
```