### PR TITLE
Initial Duplicate Object Field Handling

### DIFF
--- a/src/css/jsoneditor.css
+++ b/src/css/jsoneditor.css
@@ -80,6 +80,14 @@
   border-radius: 2px;
 }
 
+.jsoneditor .field.duplicate,
+.jsoneditor .field.duplicate:hover,
+.jsoneditor .field.duplicate:focus {
+  background-color: pink;
+  border: 1px solid red;
+  border-radius: 2px;
+}
+
 .jsoneditor div.tree button {
   width: 24px;
   height: 24px;

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -1176,6 +1176,18 @@ Node.prototype._updateDomField = function () {
       util.removeClassName(domField, 'highlight');
     }
 
+    if (this.parent && this.parent.type == "object") {
+      if (this.parent.childFields[this.field].indexOf(this) != 0) {
+        util.addClassName(domField, 'duplicate');
+        this.dom.tr.title = "Duplicate field";
+        domField.title = "Duplicate field";
+      } else {
+        util.removeClassName(domField, 'duplicate');
+        this.dom.tr.title = "";
+        domField.title - "";
+      }
+    }
+
     // strip formatting from the contents of the editable div
     util.stripFormatting(domField);
   }

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -257,6 +257,30 @@ treemode.search = function (text) {
 };
 
 /**
+ * Gets a node by its relative path from this node.  The path is represented
+ * as an array containing strings, integers, or arrays of the format
+ * ["fieldName", index").  A integer in the array signifies that the parent
+ * node is an array and the child is looked up by its index.  A string
+ * indicates that the parent is an object node and that the child is
+ * looked up by field name.  Since fields within an object can be duplicated
+ * while editing, when specifying a string the FIRST field with the matching
+ * name will be used.  To access an "invalid" duplicate field, the array
+ * element is used.  The first element in the array indicates the field name.
+ * The second element in the array specifies the number (in order) of the
+ * duplicate field.  For example if an object has three fields called foo
+ * the path ["foo"] will return the first child with field foo.  The path
+ * [['foo', 0]] will return the second child with the field foo.  The path
+ * [['foo', 1]] will return the third child with the field foo.
+ *
+ * @param path An array representing the path to a node from the root node.
+ *
+ * @return {Node} the node corresponding to the path, or null.
+ */
+treemode.getNode = function(path) {
+  return this.node.getChild(path);
+};
+
+/**
  * Expand all nodes
  */
 treemode.expandAll = function () {


### PR DESCRIPTION
This implements a basic ability handle duplicate keys within the same object.  There are several main changes.  The changes focus on the ability to detect, handle, and display duplicate nodes in the treemode.

1) Nodes know know the properties of their children.

In the current only the node itself knows about its field.  The parent only can index by the position in the child array.  A new property was added to the Node class called "childFields".  This has several benefits.  First if you know the path to an object you can now get from a parent object to its children without having to loop over the childs array.  Second the parent can now detect duplicates.

2) Path structure changes.

The path was normally only a string or an integer.  This remains the same for VALID JSON where no duplicate keys exist in an object.  If a duplicate key exists, then that nodes path will represented by an array in the path.  The array will look like this ['fieldName', duplicateIndex].  So a path might look like this:  [1, "foo", ["dupKey", 1], "bar"].  This would indicate that the dupKey field is duplicated and the path is referring to the first duplicate.  Given the following JSON:

```
{
  "foo": {
    "dupKey": A,
    "xxx": B,
    "dupKey": C,
    "dupKey": D
  }
}
```

The paths: 
- ["foo", "dupKey"] = D
- ["foo", ["dupKey", 0]] = A
- ["foo", ["dupKey",1]] = C

The last child in a given object will take precedence an be the child which is referenced using just the normal field name.  This is the only child that will be converted to JSON when saving the data or switching to text mode.  It is the "actual" value in the model.  Any nodes prior to the last one with the same field name are the duplicates.  They are in an error state and are not part of the actual JSON data.  Therefore they must be referenced with a special path key.  The Node.path() method has been updated to generate paths like this.  Perviously, all duplicate keys would have had an identical path, making them indistinguishable.


3) Editor and Node path lookups

Since the user could get the nodes path, it makes sense for them to retrieve the node by path as well.

An Editor.getNode(path) method was added to the treemode editor.  This method will take a node path (as returned by Node.getPath()) and will return that specified node, or null if that node does not exist.  The path is absolute from the root node.

Similarly, a Node.getChild(path) method was added that gets a child node of the node the method was called on with the relative path between the two.  When the editor is asked for a node, it essentially calls this method on the root node.  

4) Duplicate node rendering

The tree mode now renders nodes with duplicate field names within the same object as duplicates.  The last duplicate node is not marked as being in error.  Any prior nodes are now highlighted in red.  Markings are update as nodes are renamed or moved.
