### PR TITLE
Enter / Shift+Enter Editing Completion

### DIFF
--- a/src/css/jsoneditor.css
+++ b/src/css/jsoneditor.css
@@ -58,10 +58,15 @@
   color: gray;
 }
 
-.jsoneditor .field[contenteditable=true]:focus,
 .jsoneditor .field[contenteditable=true]:hover,
+.jsoneditor .value[contenteditable=true]:hover {
+  background-color: #ECF5FF;
+  border: 1px solid #8A96BE;
+  border-radius: 2px;
+}
+
+.jsoneditor .field[contenteditable=true]:focus,
 .jsoneditor .value[contenteditable=true]:focus,
-.jsoneditor .value[contenteditable=true]:hover,
 .jsoneditor .field.highlight,
 .jsoneditor .value.highlight {
   background-color: #FFFFAB;

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -1828,6 +1828,11 @@ Node.prototype.onEvent = function (event) {
         break;
 
       case 'keydown':
+        if (event.keyCode == 13 && this.editor.options.completeOnEnter == !event.shiftKey) {
+          event.preventDefault();
+          domValue.blur();
+          break;
+        }
       case 'mousedown':
         this.editor.selection = this.editor.getSelection();
         break;
@@ -1878,6 +1883,11 @@ Node.prototype.onEvent = function (event) {
         break;
 
       case 'keydown':
+        if (event.keyCode == 13 && this.editor.options.completeOnEnter == !event.shiftKey) {
+          event.preventDefault();
+          domField.blur();
+          break;
+        }
       case 'mousedown':
         this.editor.selection = this.editor.getSelection();
         break;

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -22,6 +22,12 @@ var treemode = {};
  *                               {function} change  Callback method, triggered
  *                                                  on change of contents
  *                               {String} name      Field name for the root node.
+ *                               {String} completeOnEnter
+ *                                  If true, enables editing completion by hitting enter. To insert
+ *                                  a newline user can hit shift+enter.  If false, hitting enter
+ *                                  will insert a newline.  To complete, the user can hit shift+
+ *                                  enter.  False by default.
+ *
  * @private
  */
 treemode.create = function (container, options) {
@@ -63,7 +69,8 @@ treemode._setOptions = function (options) {
     search: true,
     history: true,
     mode: 'tree',
-    name: undefined   // field name of root node
+    name: undefined,   // field name of root node
+    completeOnEnter: false
   };
 
   // copy all options


### PR DESCRIPTION
This is a simple pull request that enable the user to complete editing of a field by either hitting enter or shift enter.  Currently the user needs to click out of the field.  A new option was added for tree mode call "completeOnEnter".  If set to true, then pressing enter will cause the edit to be completed.  In this case the user can still enter a newline by pressing shift+enter.  If "completeOnEnter" is set to false, the pressing enter will add a newline as it does now.  In this mode, the user can press shift+enter to complete the editing.

The completeOnEnter option is False by default which preserves the default behavior of the code for backwards compatibility.