### PR TITLE
Add an 'onMode' callback option which is invoked after setMode finishes.

### DIFF
--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -169,6 +169,13 @@ JSONEditor.prototype.setMode = function (mode) {
         }
         catch (err) {}
       }
+
+      if (typeof options.onMode === 'function') {
+        try {
+          options.onMode(options.mode);
+        }
+        catch (err) {}
+      }
     }
     catch (err) {
       this._onError(err);

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -23,6 +23,8 @@ var textmode = {};
  *                                                         spaces. 2 by default.
  *                                   {function} change     Callback method
  *                                                         triggered on change
+ *                                   {function} onMode     Callback method
+ *                                                         triggered after setMode
  *                                   {Object} ace          A custom instance of
  *                                                         Ace editor.
  * @private


### PR DESCRIPTION
I needed a way to track the current mode of the JSONEditor and discovered there is no simple way to get this information.  

This is a much nicer version of the monkey patch I did locally.