### PR TITLE
Error if 'search' option set to false

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,11 @@
 https://github.com/josdejong/jsoneditor
 
 
+## not yet released, version 5.1.1
+
+- Fixed #255: Removed wrong console warning about the option `search`.
+
+
 ## 2016-01-14, version 5.1.0
 
 - Implemented support for JSON schema validation, powered by `ajv`.

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -77,7 +77,7 @@ function JSONEditor (container, options, json) {
         'ace', 'theme',
         'ajv', 'schema',
         'onChange', 'onEditable', 'onError', 'onModeChange',
-        'escapeUnicode', 'history', 'mode', 'modes', 'name', 'indentation'
+        'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation'
       ];
 
       Object.keys(options).forEach(function (option) {

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -145,7 +145,9 @@ treemode.set = function (json, name) {
   }
 
   // clear search
-  this.searchBox.clear();
+  if (this.searchBox) {
+    this.searchBox.clear();
+  }
 };
 
 /**


### PR DESCRIPTION
Fixed error "Cannot read property 'clear' of undefined" thrown if `search` option set to `false`.