### PR TITLE
browserify build fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,6 +41,11 @@ var compiler = webpack({
     filename: NAME + '.js'
   },
   plugins: [ bannerPlugin ],
+  module: {
+    loaders: [
+      { test: /\.json$/, loader: "json" }
+    ]
+  },
   cache: true
 });
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-minify-css": "^0.4.5",
     "gulp-shell": "^0.3.0",
     "gulp-util": "^3.0.3",
+    "json-loader": "^0.5.4",
     "mkdirp": "^0.5.0",
     "mocha": "^2.1.0",
     "uglify-js": "^2.4.16",

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -1,6 +1,6 @@
 var Ajv;
 try {
-  Ajv = require('ajv/dist/ajv.bundle.js');
+  Ajv = require('ajv');
 }
 catch (err) {
   // no problem... when we need Ajv we will throw a neat exception


### PR DESCRIPTION
browserify build of master is currently broken:

    $ browserify --version
    13.0.0
    $ browserify ./index.js -o ./jsoneditor.custom.js -s JSONEditor
    Error: Cannot find module './decode' from '/home/onip/workspace/jsoneditor/node_modules/ajv/dist'
        at /home/onip/workspace/node_tools/node_modules/browserify/node_modules/resolve/lib/async.js:55:21
        at load (/home/onip/workspace/node_tools/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
        at onex (/home/onip/workspace/node_tools/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
        at /home/onip/workspace/node_tools/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
        at FSReqWrap.oncomplete (fs.js:82:15)

this PR fixes browserify building while keeping a fully working webpack environment: both mocha tests and validation example (n. 7) work just fine.