### PR TITLE
i18n for validation error messages and add lang option

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "ajv": "3.4.0",
+    "ajv-i18n": "1.0.0",
     "brace": "0.7.0"
   },
   "devDependencies": {

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -77,7 +77,7 @@ function JSONEditor (container, options, json) {
         'ace', 'theme',
         'ajv', 'schema',
         'onChange', 'onEditable', 'onError', 'onModeChange',
-        'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation'
+        'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation', 'lang'
       ];
 
       Object.keys(options).forEach(function (option) {

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -6,6 +6,7 @@ catch (err) {
   // failed to load ace, no problem, we will fall back to plain text
 }
 
+var localize = require('ajv-i18n');
 var modeswitcher = require('./modeswitcher');
 var util = require('./util');
 
@@ -409,6 +410,7 @@ textmode.validate = function () {
   if (doValidate && this.validateSchema) {
     var valid = this.validateSchema(json);
     if (!valid) {
+      this._translate(this.validateSchema.errors);
       errors = this.validateSchema.errors.map(function (error) {
         return util.improveSchemaError(error);
       });
@@ -454,6 +456,13 @@ textmode.validate = function () {
   if (this.aceEditor) {
     var force = false;
     this.aceEditor.resize(force);
+  }
+};
+
+textmode._translate = function(errors) {
+  var fn = localize[this.options.lang];
+  if (fn !== undefined && fn !== null) {
+    fn(errors);
   }
 };
 

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -1,3 +1,4 @@
+var localize = require('ajv-i18n')
 var Highlighter = require('./Highlighter');
 var History = require('./History');
 var SearchBox = require('./SearchBox');
@@ -373,6 +374,7 @@ treemode.validate = function () {
     var valid = this.validateSchema(root.getValue());
     if (!valid) {
       // apply all new errors
+      this._translate(this.validateSchema.errors);
       schemaErrors = this.validateSchema.errors
           .map(function (error) {
             return util.improveSchemaError(error);
@@ -415,6 +417,13 @@ treemode.validate = function () {
         entry.node.setError(entry.error, entry.child);
         return entry.node;
       });
+};
+
+treemode._translate = function(errors) {
+  var fn = localize[this.options.lang];
+  if (fn !== undefined && fn !== null) {
+    fn(errors);
+  }
 };
 
 /**


### PR DESCRIPTION
Add i18n for validation error messges using ajv-i18n.
Also add 'lang' option to choose which language will be used for the i18n.