### PR TITLE
Add option to sort objects keys alphabetically

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -68,6 +68,10 @@ Constructs a new JSONEditor.
 
   If true, unicode characters are escaped and displayed as their hexadecimal code (like `\u260E`) instead of of the character itself (like `☎`). False by default.
 
+- `{boolean} sortObjectKeys`
+
+  If true, object keys in 'tree', 'view' or 'form' mode list be listed alphabetically instead by their insertion order. Sorting is performed using a natural sort algorithm, which makes it easier to see objects that have string numbers as keys. False by default.
+
 - `{boolean} history`
 
   Enables history, adds a button Undo and Redo to the menu of the JSONEditor. True by default. Only applicable when `mode` is 'tree' or 'form'.

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -39,6 +39,9 @@ var util = require('./util');
  *                               {boolean} escapeUnicode  If true, unicode
  *                                                        characters are escaped.
  *                                                        false by default.
+ *                               {boolean} sortObjectKeys If true, object keys are
+ *                                                        sorted before display.
+ *                                                        false by default.
  * @param {Object | undefined} json JSON object
  */
 function JSONEditor (container, options, json) {
@@ -77,7 +80,7 @@ function JSONEditor (container, options, json) {
         'ace', 'theme',
         'ajv', 'schema',
         'onChange', 'onEditable', 'onError', 'onModeChange',
-        'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation'
+        'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation', 'sortObjectKeys'
       ];
 
       Object.keys(options).forEach(function (option) {


### PR DESCRIPTION
The new option is disabled by default, but when enabled makes editing large documents in tree or form mode much easier.

It also includes the nicety of being a natural sort, so object that have numbers inside strings as keys sort very well.