### PR TITLE
Fix context menu CSS when used with Bootstrap.

### DIFF
--- a/src/css/contextmenu.css
+++ b/src/css/contextmenu.css
@@ -13,6 +13,11 @@ div.jsoneditor-contextmenu {
   z-index: 99999;
 }
 
+div.jsoneditor-contextmenu ul,
+div.jsoneditor-contextmenu li {
+  box-sizing: content-box;
+}
+
 div.jsoneditor-contextmenu ul {
   position: relative;
   left: 0;


### PR DESCRIPTION
Made a small CSS fix for the context menu.

Before:

<img width="1440" alt="screen shot 2016-04-11 at 12 03 53 pm" src="https://cloud.githubusercontent.com/assets/914228/14433790/b0c3803c-ffdd-11e5-80c2-529f227f222b.png">

After:

<img width="1440" alt="screen shot 2016-04-11 at 12 04 03 pm" src="https://cloud.githubusercontent.com/assets/914228/14433797/b6197e42-ffdd-11e5-9e97-64c1f11e2988.png">

Also, fyi I wrapped jsoneditor in an Ember component [here](https://github.com/nucleartide/ember-json-editor-for). This editor is awesome. :)