### PR TITLE
Optimize the input experience of Chinese IME

### DIFF
--- a/src/js/ace/theme-jsoneditor.js
+++ b/src/js/ace/theme-jsoneditor.js
@@ -40,6 +40,7 @@ color: #333\
 .ace-jsoneditor.ace_editor {\
 font-family: droid sans mono, consolas, monospace, courier new, courier, sans-serif;\
 line-height: 1.3;\
+background-color: #fff;\
 }\
 .ace-jsoneditor .ace_print-margin {\
 width: 1px;\


### PR DESCRIPTION
By default, ace accepts user inputs by textarea.ace_text-input, which has a cursor. If typing with IME, another cursor appears.

In the next picture, line 11 has the first cursor at the right of "a", while the second one is after "wen"(it is flashing, not very clear).

![4 pic](https://cloud.githubusercontent.com/assets/1736154/24495985/8f4279fc-1569-11e7-9928-8dad697d7ea2.png)

In fact, ace tries to avoid this situation by setting z-index of class ace_composition, which is added to textarea.ace_text-input in composition input mode. But its background color is "inherit". If the parent element's background color is transparent, the first cursor can not be covered.

Official themes of ace always set background color of the parent element. So maybe our theme-jsoneditor should keep the same. After fixed, the input experience is better.

![3 pic 1](https://cloud.githubusercontent.com/assets/1736154/24499021/edbf2260-1572-11e7-90fe-0cb58201c915.png)

ps. I think minor PRs can be send to master directly. But if you persist, I will fix them.
