### PR TITLE
#382 Read only text mode.

### DIFF
--- a/examples/06_readonly_text_mode.html
+++ b/examples/06_readonly_text_mode.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>JSONEditor | Switch mode</title>
+
+  <!-- when using the mode "code", it's important to specify charset utf-8 -->
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    body {
+      font: 10.5pt arial;
+      color: #4d4d4d;
+      line-height: 150%;
+      width: 500px;
+    }
+
+    code {
+      background-color: #f5f5f5;
+    }
+
+    #jsoneditor {
+      width: 500px;
+      height: 500px;
+    }
+  </style>
+</head>
+<body>
+
+<p>
+  Switch editor mode using the mode box.
+  Note that the mode can be changed programmatically as well using the method
+  <code>editor.setMode(mode)</code>, try it in the console of your browser.
+</p>
+
+<div id="jsoneditor"></div>
+
+<script>
+  var container = document.getElementById('jsoneditor');
+
+  var options = {
+    mode: 'text',
+    modes: ['text'],
+    onEditable: function() { //absence of key makes the text area not readOnly
+      return false; // returning false makes the text area readOnly
+    },
+    onError: function (err) {
+      alert(err.toString());
+    },
+    onModeChange: function (newMode, oldMode) {
+      console.log('Mode switched from', oldMode, 'to', newMode);
+    }
+  };
+
+  var json = {
+    "array": [1, 2, 3],
+    "boolean": true,
+    "null": null,
+    "number": 123,
+    "object": {"a": "b", "c": "d"},
+    "string": "Hello World"
+  };
+
+  var editor = new JSONEditor(container, options, json);
+</script>
+</body>
+</html>

--- a/examples/09_readonly_text_mode.html
+++ b/examples/09_readonly_text_mode.html
@@ -42,7 +42,7 @@
 
   var options = {
     mode: 'text',
-    modes: ['text'],
+    modes: ['text', 'code'],
     onEditable: function() { //absence of key makes the text area not readOnly
       return false; // returning false makes the text area readOnly
     },

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -31,6 +31,8 @@ var DEFAULT_THEME = 'ace/theme/jsoneditor';
  *                                                       triggered on change
  *                             {function} onModeChange   Callback method
  *                                                       triggered after setMode
+ *                             {function} onEditable     Determine if textarea is readOnly
+ *                                                       readOnly defaults true
  *                             {Object} ace              A custom instance of
  *                                                       Ace editor.
  *                             {boolean} escapeUnicode   If true, unicode
@@ -201,6 +203,13 @@ textmode.create = function (container, options) {
     textarea.spellcheck = false;
     this.content.appendChild(textarea);
     this.textarea = textarea;
+
+    var emptyNode = {};
+    var isReadOnly = (this.options.onEditable
+        && typeof(this.options.onEditable === 'Function')
+        && !this.options.onEditable(emptyNode));
+
+    this.textarea.readOnly = isReadOnly;
 
     // register onchange event
     if (this.textarea.oninput === null) {

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -206,7 +206,7 @@ textmode.create = function (container, options) {
 
     var emptyNode = {};
     var isReadOnly = (this.options.onEditable
-        && typeof(this.options.onEditable === 'Function')
+        && typeof(this.options.onEditable === 'function')
         && !this.options.onEditable(emptyNode));
 
     this.textarea.readOnly = isReadOnly;

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -141,6 +141,11 @@ textmode.create = function (container, options) {
     });
   }
 
+  var emptyNode = {};
+  var isReadOnly = (this.options.onEditable
+  && typeof(this.options.onEditable === 'function')
+  && !this.options.onEditable(emptyNode));
+
   this.content = document.createElement('div');
   this.content.className = 'jsoneditor-outer';
   this.frame.appendChild(this.content);
@@ -156,6 +161,7 @@ textmode.create = function (container, options) {
     var aceEditor = _ace.edit(this.editorDom);
     aceEditor.$blockScrolling = Infinity;
     aceEditor.setTheme(this.theme);
+    aceEditor.setOptions({ readOnly: isReadOnly });
     aceEditor.setShowPrintMargin(false);
     aceEditor.setFontSize(13);
     aceEditor.getSession().setMode('ace/mode/json');
@@ -203,12 +209,6 @@ textmode.create = function (container, options) {
     textarea.spellcheck = false;
     this.content.appendChild(textarea);
     this.textarea = textarea;
-
-    var emptyNode = {};
-    var isReadOnly = (this.options.onEditable
-        && typeof(this.options.onEditable === 'function')
-        && !this.options.onEditable(emptyNode));
-
     this.textarea.readOnly = isReadOnly;
 
     // register onchange event


### PR DESCRIPTION
Addresses [#382](https://github.com/josdejong/jsoneditor/issues/382). I have also added an example file in addition to the changes in `./src`. I didn't want to make the surface area of `options` any larger, so I decided to use `onEditable` to determine if the textarea in `text` mode is editable. If the `onEditable` key is absent in the `options` than the content is editable. If the key is present and has a value that is a function, it will determine whether the text area is editable based on the result of `onEditable`'s invocation.

If hijacking the `onEditable` option is not appropriate I'd love to chat about the desired api of `options`.