### PR TITLE
Update Ajv version to prevent spurious warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha test"
   },
   "dependencies": {
-    "ajv": "4.11.6",
+    "ajv": "5.1.0",
     "brace": "0.10.0",
     "javascript-natural-sort": "0.7.1"
   },


### PR DESCRIPTION
This PR updates `ajv@4.11.6` to `ajv@5.1.0`.

---

When building via Webpack, there’s some spurious warnings coming from `ajv` -- see https://github.com/epoberezkin/ajv/issues/117.

```
WARNING in ./~/jsoneditor/~/ajv/lib/async.js
96:20-33 Critical dependency: the request of a dependency is an expression

WARNING in ./~/jsoneditor/~/ajv/lib/async.js
119:15-28 Critical dependency: the request of a dependency is an expression

WARNING in ./~/jsoneditor/~/ajv/lib/compile/index.js
13:21-34 Critical dependency: the request of a dependency is an expression
```

A solution is to just add the following snippet to our `webpack.config.js` to ignore these warnings. This isn’t possible though if a dev is building via the Angular CLI as it actually doesn’t expose the underlying Webpack config.

```javascript
plugins: [
  new webpack.IgnorePlugin(/regenerator|nodent|js-beautify/, /ajv/),
  ...
]
```

In the referenced issue above, the author addresses the issue was fixed in `ajv@5.0.1-beta.3` (see https://github.com/epoberezkin/ajv/issues/117#issuecomment-269205559). Since their latest release is currently at `5.1.0` though, I've updated `ajv` to that.

---

Tests all pass and the project still works great as before! Just no more warnings when building via Webpack or the Angular CLI now! Lemme know if I missed something!
