### PR TITLE
Enabled the default mode to be set when using a list of available modes.

### DIFF
--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -130,7 +130,7 @@ JSONEditor.prototype._create = function (container, options, json) {
   this.options = options || {};
   this.json = json || {};
 
-  var mode = this.options.mode || 'tree';
+  var mode = this.options.modes ? this.options.modes[0] : this.options.mode || 'tree';
   this.setMode(mode);
 };
 


### PR DESCRIPTION
I noticed that when using a list of available modes say `[ 'code', 'form', 'tree' ]`, that `tree` would always be selected as the default, when it would be nice to be able to have the first mode in the list used as the default. 

Upon further inspection I also realised that if `tree` wasn't in the list it would still be shown as the default, and then not made available as an option to change to, so the user would only see it on first load. 

This simple change fixes these issues.