### PR TITLE
Implement support for Toolbar and Context Menu plugins

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -197,6 +197,62 @@ Constructs a new JSONEditor.
 
      The callback function when the custom button is clicked. Called without parameters.
 
+- `{Object[]} contextMenuPlugins`
+
+  Adds custom actions to the context menu when a single node is selected. Contains **subelements**:
+
+  - `{string} type`
+
+     If type === 'separator', this object represents a separator in the context menu.  All other properties will be ignored.
+
+  - `{string} text`
+
+     The action's text, for example `Action Name`.
+
+  - `{string} title`
+
+     The action's title (tooltip) text, for example `A longer description of the action`.
+
+  - `{string} className`
+
+     To be consistent with standard buttons, use `jsoneditor-<name>`, for example `jsoneditor-fullscreen`.
+
+  - `{Function} _click (nodes)`
+
+     The callback function when the custom action is clicked. Called with the selected nodes.
+
+  - `{Object[]} submenu`
+
+     Submenu items of the same type as `contextMenuPlugins`.
+
+- `{Object[]} multiContextMenuPlugins`
+
+  Adds custom actions to the context menu when multiple nodes are selected. Contains **subelements**:
+
+  - `{string} type`
+
+     If type === 'separator', this object represents a separator in the context menu.  All other properties will be ignored.
+
+  - `{string} text`
+
+     The action's text, for example `Action Name`.
+
+  - `{string} title`
+
+     The action's title (tooltip) text, for example `A longer description of the action`.
+
+  - `{string} className`
+
+     To be consistent with standard buttons, use `jsoneditor-<name>`, for example `jsoneditor-fullscreen`.
+
+  - `{Function} _click (nodes)`
+
+     The callback function when the custom action is clicked. Called with the selected nodes.
+
+  - `{Object[]} submenu`
+
+     Submenu items of the same type as `multiContextMenuPlugins`.
+
 
 ### Methods
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,6 +180,23 @@ Constructs a new JSONEditor.
      - Can return an object `{startFrom: number, options: string[]}`. Here `startFrom` determines the start character from where the existing text will be replaced. `startFrom` is `0` by default, replacing the whole text.
      - Can return a `Promise` resolving one of the return types above to support asynchronously retrieving a list with options.
 
+- `{Object[]} toolbarPlugins`
+
+  Adds custom buttons to the toolbar. Contains **subelements**:
+
+  - `{string} title`
+
+     The button's title text, for example `Expand to fullscreen`.
+
+  - `{string} className`
+
+     To be consistent with standard buttons, use `jsoneditor-<name>`, for example `jsoneditor-fullscreen`.
+     To add a spacer on the left, include class `jsoneditor-separator`, for example `jsoneditor-fullscreen jsoneditor-separator`.
+
+  - `{Function} onclick`
+
+     The callback function when the custom button is clicked. Called without parameters.
+
 
 ### Methods
 

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -48,6 +48,16 @@ var util = require('./util');
  *                                                          buttons.  Must contain
  *                                                          `title`, `className`, and
  *                                                          `onclick` properties.
+ *                               {Object[]} contextMenuPlugins  Array of custom toolbar
+ *                                                              buttons.  Must contain
+ *                                                              'text', `title`, `className`,
+ *                                                              and either `_click` or
+ *                                                              `submenu` properties.
+ *                               {Object[]} multiContextMenuPlugins     Array of custom toolbar
+ *                                                                      buttons.  Must contain
+ *                                                                      'text', `title`, `className`,
+ *                                                                      and either `_click` or
+ *                                                                      `submenu` properties.
  * @param {Object | undefined} json JSON object
  */
 function JSONEditor (container, options, json) {
@@ -87,7 +97,7 @@ function JSONEditor (container, options, json) {
         'ace', 'theme','autocomplete',
         'onChange', 'onEditable', 'onError', 'onModeChange',
         'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation', 'sortObjectKeys',
-        'toolbarPlugins'
+        'toolbarPlugins', 'contextMenuPlugins', 'multiContextMenuPlugins'
       ];
 
       Object.keys(options).forEach(function (option) {

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -44,6 +44,10 @@ var util = require('./util');
  *                               {boolean} sortObjectKeys If true, object keys are
  *                                                        sorted before display.
  *                                                        false by default.
+ *                               {Object[]} toolbarPlugins  Array of custom toolbar
+ *                                                          buttons.  Must contain
+ *                                                          `title`, `className`, and
+ *                                                          `onclick` properties.
  * @param {Object | undefined} json JSON object
  */
 function JSONEditor (container, options, json) {
@@ -82,7 +86,8 @@ function JSONEditor (container, options, json) {
         'ajv', 'schema', 'schemaRefs','templates',
         'ace', 'theme','autocomplete',
         'onChange', 'onEditable', 'onError', 'onModeChange',
-        'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation', 'sortObjectKeys'
+        'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation', 'sortObjectKeys',
+        'toolbarPlugins'
       ];
 
       Object.keys(options).forEach(function (option) {

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -753,6 +753,31 @@ treemode._createFrame = function () {
     });
   }
 
+  // create custom toolbar buttons
+  if (this.options && this.options.toolbarPlugins && this.options.toolbarPlugins.length) {
+    for (var i in this.options.toolbarPlugins) {
+      var customButtonOpts = this.options.toolbarPlugins[i];
+
+      // skip this plugin if these properties don't exist
+      if (!customButtonOpts.title || !customButtonOpts.className || !customButtonOpts.onclick) {
+        console.error("Toolbar plugin is being skipped for missing mandatory properties (title, className, onclick): " +
+                        JSON.stringify(customButtonOpts));
+        continue;
+      }
+
+      // create the basic button
+      var customButton = document.createElement('button');
+      customButton.type = 'button';
+
+      // merge the provided options to the button
+      for (var option in customButtonOpts) {
+        customButton[option] = customButtonOpts[option];
+      }
+
+      this.menu.appendChild(customButton);
+    }
+  }
+
   // create search box
   if (this.options.search) {
     this.searchBox = new SearchBox(this, this.menu);

--- a/test/test_plugins.html
+++ b/test/test_plugins.html
@@ -1,0 +1,192 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    body {
+      font: 10.5pt arial;
+      color: #4d4d4d;
+      line-height: 150%;
+      width: 500px;
+      padding-left: 40px;
+    }
+
+    code {
+      background-color: #f5f5f5;
+    }
+
+    #jsoneditor {
+      width: 500px;
+      height: 500px;
+    }
+  </style>
+</head>
+<body>
+
+<p>
+  Switch editor mode using the mode box.
+  Note that the mode can be changed programmatically as well using the method
+  <code>editor.setMode(mode)</code>, try it in the console of your browser.
+</p>
+
+<div id="jsoneditor"></div>
+
+<script>
+  var container = document.getElementById('jsoneditor');
+
+  var options = {
+    mode: 'tree',
+    modes: ['code', 'form', 'text', 'tree', 'view'], // allowed modes
+    onError: function (err) {
+      console.error(err);
+    },
+    toolbarPlugins: [
+      {
+        title: 'Custom button 1 with separator',
+        className: 'jsoneditor-button1 jsoneditor-separator',
+        onclick: function() { alert('Button 1'); }
+      },
+      {
+        title: 'Custom button 2 without separator',
+        className: 'jsoneditor-button2',
+        onclick: function() { alert('Button 2'); }
+      },
+      {
+        className: 'jsoneditor-invalidbutton1',
+        onclick: function() { alert('Invalid button 1'); }
+      },
+      {
+        title: 'Invalid button 2',
+        onclick: function() { alert('Invalid button 2'); }
+      },
+      {
+        title: 'Invalid button 3',
+        className: 'jsoneditor-invalidbutton3'
+      }
+    ],
+    contextMenuPlugins: [
+      {
+        type: 'separator'
+      },
+      {
+        text: 'Click',
+        title: 'Action with click',
+        className: 'jsoneditor-action1',
+        _click: function(node) {
+          alert('Action 1');
+          alert(node);
+        }
+      },
+      {
+        text: 'Submenu',
+        title: 'Action with submenu',
+        className: 'jsoneditor-action2',
+        submenu: [
+          {
+            text: 'Submenu 1',
+            title: 'New subaction 1',
+            className: 'jsoneditor-sa1',
+            _click: function(node) { alert('subaction 1'); }
+          },
+          {
+            title: 'Invalid Submenu 1',
+            className: 'jsoneditor-invalidsa1',
+            _click: function(node) { alert('subaction 1'); }
+          },
+          {
+            text: 'submenu 2',
+            className: 'jsoneditor-invalidsa2',
+            _click: function(node) { alert('subaction 2'); }
+          },
+          {
+            text: 'submenu 3',
+            title: 'Invalid Submenu 3',
+            _click: function(node) { alert('subaction 3'); }
+          },
+          {
+            text: 'submenu 4',
+            title: 'Invalid submenu 4',
+            className: 'jsoneditor-invalidsa4',
+          }
+        ]
+      },
+      {
+        text: 'Submenu+Click',
+        title: 'Action with submenu and click',
+        className: 'jsoneditor-action3',
+        _click: function(node) {
+          alert('Action 3');
+          alert(node);
+        },
+        submenu: [
+          {
+            text: 'Submenu 1',
+            title: 'New subaction 1',
+            className: 'jsoneditor-sa1',
+            _click: function(node) { alert('subaction 1'); }
+          }
+        ]
+      },
+      {
+        text: 'Custom C',
+        title: 'New action 3',
+        _click: function(node) {
+          alert('Action 3');
+        }
+      }
+    ],
+    multiContextMenuPlugins: [
+      {
+        text: 'Multi1',
+        title: 'New multiselect action 1',
+        className: 'jsoneditor-msaction1',
+        _click: function(nodes) { alert('Action 1'); }
+      },
+      {
+        title: 'New multiselect action 2',
+        className: 'jsoneditor-msaction2',
+        _click: function(nodes) { alert('Action 2'); }
+      },
+      {
+        text: 'Multi3',
+        className: 'jsoneditor-msaction3',
+        _click: function(nodes) { alert('Action 3'); }
+      },
+      {
+        text: 'Multi4',
+        title: 'New multiselect action 4',
+        _click: function(nodes) { alert('Action 4'); }
+      },
+      {
+        text: 'Multi5',
+        title: 'New multiselect action 5',
+        className: 'jsoneditor-msaction5',
+      }
+    ]
+  };
+
+  var json = {
+    "firstName": "Jos",
+    "lastName": "de Jong",
+    gender: null,
+    "age": 34.2,
+    "hobbies": [
+        "programming",
+        "movies",
+        "bicycling"
+    ]
+  };
+
+  var editor = new JSONEditor(container, options, json);
+
+  console.log('json', json);
+  console.log('toolbarPlugins', options.toolbarPlugins);
+  console.log('contextMenuPlugins', options.contextMenuPlugins);
+  console.log('multiContextMenuPlugins', options.multiContextMenuPlugins);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Related to #435.  This adds options for easily defining additional buttons to the Toolbar and Context Menu.  Though multi-select is currently broken, this should support additional custom Context Menu options for multiple selections.

---
This contribution is graciously provided by **XumaK** (http://xumak.com/)

_XumaK helps reduce the uncertainty and risk that is normally involved for companies trying to transform themselves digitally._  

_We provide professional services teams with years of experience to deliver the project, using our end-to-end delivery platform, which ensures your project will be on time and on budget. We deliver world class customer solutions through innovative industry leading products._