### PR TITLE
Allow for custom History actions

### DIFF
--- a/src/js/History.js
+++ b/src/js/History.js
@@ -150,9 +150,13 @@ History.prototype.onChange = function () {};
 
 /**
  * Add a new action to the history
- * @param {String} action  The executed action. Available actions: "editField",
+ * @param {String or Object}    action
+ *                         The executed action. Built-in actions can be
+ *                         referenced by name: "editField",
  *                         "editValue", "changeType", "appendNode",
- *                         "removeNode", "duplicateNode", "moveNode"
+ *                         "removeNode", "duplicateNode", "moveNode".
+ *                         Alternatively, an action Object can be provided
+ *                         with undo and redo functions.
  * @param {Object} params  Object containing parameters describing the change.
  *                         The parameters in params depend on the action (for
  *                         example for "editValue" the Node, old value, and new
@@ -210,7 +214,7 @@ History.prototype.undo = function () {
   if (this.canUndo()) {
     var obj = this.history[this.index];
     if (obj) {
-      var action = this.actions[obj.action];
+      var action = obj.action instanceof Object ? obj.action : this.actions[obj.action];
       if (action && action.undo) {
         action.undo(obj.params);
         if (obj.params.oldSelection) {
@@ -237,7 +241,7 @@ History.prototype.redo = function () {
 
     var obj = this.history[this.index];
     if (obj) {
-      var action = this.actions[obj.action];
+      var action = obj.action instanceof Object ? obj.action : this.actions[obj.action];
       if (action && action.redo) {
         action.redo(obj.params);
         if (obj.params.newSelection) {

--- a/test/test_history_actions.html
+++ b/test/test_history_actions.html
@@ -1,0 +1,78 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    body {
+      font: 10.5pt arial;
+      color: #4d4d4d;
+      line-height: 150%;
+      width: 500px;
+      padding-left: 40px;
+    }
+
+    code {
+      background-color: #f5f5f5;
+    }
+
+    #jsoneditor {
+      width: 500px;
+      height: 500px;
+    }
+  </style>
+</head>
+<body>
+
+<p>
+  Switch editor mode using the mode box.
+  Note that the mode can be changed programmatically as well using the method
+  <code>editor.setMode(mode)</code>, try it in the console of your browser.
+</p>
+
+<div id="jsoneditor"></div>
+
+<script>
+  var container = document.getElementById('jsoneditor');
+
+  var historyAction = {
+    'undo':function(params) { alert('undo params = ' + JSON.stringify(params)); },
+    'redo':function(params) { alert('redo params = ' + JSON.stringify(params)); }
+  }
+
+  var options = {
+    mode: 'tree',
+    modes: ['code', 'form', 'text', 'tree', 'view'], // allowed modes
+    onError: function (err) {
+      console.error(err);
+    }
+  };
+
+  var json = {
+    "firstName": "Jos",
+    "lastName": "de Jong",
+    gender: null,
+    "age": 34.2,
+    "hobbies": [
+        "programming",
+        "movies",
+        "bicycling"
+    ]
+  };
+
+  var editor = new JSONEditor(container, options, json);
+
+  // submit the custom action
+  editor._onAction(historyAction, {oldNode:'oldNode',newNode:'newNode'});
+
+  // call undo and redo
+  editor._onUndo();
+  editor._onRedo();
+
+  console.log('json', json);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Minor change to allow custom History actions to be recorded.

Includes a simple test, but no documentation (other than the `History.prototype.add` docblock).