### PR TITLE
Enable displaying a node schema type instead of its value

### DIFF
--- a/examples/14_json_value_display_mode.html
+++ b/examples/14_json_value_display_mode.html
@@ -1,0 +1,132 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>JSONEditor | JSON schema validation</title>
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    body {
+      width: 600px;
+      font: 11pt sans-serif;
+    }
+    .jsoneditor {
+      width: 100%;
+      height: 250px;
+    }
+
+    table tr th {
+      text-align: left;
+    }
+  </style>
+</head>
+<body>
+<h1>Value display mode</h1>
+<p>
+  This example demonstrates the different value display modes:
+  <table>
+    <tr>
+      <th>value</th>
+      <td>displays the value of a node</td>
+    </tr>
+    <tr>
+      <th>schema</th>
+      <td>displays the schema type of a node</td>
+    </tr>
+    <tr>
+      <th>schema-if-null</th>
+      <td>displays the schema type of a node if its value is null</td>
+    </tr>
+  </table>
+</p>
+
+<h2>Value</h2>
+<div class="jsoneditor" id="jsoneditor1"></div>
+<h2>Schema</h2>
+<div class="jsoneditor" id="jsoneditor2"></div>
+<h2>Schema if null</h2>
+<div class="jsoneditor" id="jsoneditor3"></div>
+
+<script>
+  var schema = {
+    "title": "Example Schema",
+    "type": "object",
+    "properties": {
+      "firstName": {
+        "type": "string"
+      },
+      "lastName": {
+        "type": "string"
+      },
+      "gender": {
+        "enum": ["male", "female"]
+      },
+      "age": {
+        "description": "Age in years",
+        "type": "integer",
+        "minimum": 0
+      },
+      "job": {
+        "$ref": "job"
+      }
+    },
+    "required": ["firstName", "lastName"]
+  };
+
+  var job = {
+    "title": "Job description",
+    "type": "object",
+    "properties": {
+      "company": {
+        "$ref": "company"
+      },
+      "role": {
+        "type": "string"
+      }
+    }
+  };
+  var company = {
+    "title": "Company description",
+    // "type": "string"
+    "$ref": "companyType"
+  };
+  var companyType = {
+    "title": "Company type description",
+    "type": "string"
+  };
+
+  var json = {
+    firstName: 'John',
+    lastName: null,
+    gender: null,
+    age: null,
+    job: {
+      company: null,
+      role: 'developer'
+    }
+  };
+
+  var options = {
+    schema: schema,
+    schemaRefs: {"job": job, "company": company, "companyType": companyType},
+    valueDisplayMode: 'value',
+    // valueDisplayModes: ['value','schema','schema-if-null'],
+    onValueDisplayModeChange: function(mode) {
+      console.log("onValueDisplayModeChange:", "'"+mode+"'");
+    },
+    modes: ['tree', 'view']
+  };
+
+  // create the editor
+  // options.valueDisplayMode = 'schema';
+  var container = document.getElementById('jsoneditor1');
+  var editor = new JSONEditor(container, options, json);
+
+  options.valueDisplayMode = 'schema';
+  var editor2 = new JSONEditor(document.getElementById('jsoneditor2'), options, json);
+  options.valueDisplayMode = 'schema-if-null';
+  var editor3 = new JSONEditor(document.getElementById('jsoneditor3'), options, json);
+</script>
+</body>
+</html>

--- a/examples/14_json_value_display_mode.html
+++ b/examples/14_json_value_display_mode.html
@@ -42,11 +42,11 @@
 </p>
 
 <h2>Value</h2>
-<div class="jsoneditor" id="jsoneditor1"></div>
+<div class="jsoneditor" id="jsoneditor-value"></div>
 <h2>Schema</h2>
-<div class="jsoneditor" id="jsoneditor2"></div>
+<div class="jsoneditor" id="jsoneditor-schema"></div>
 <h2>Schema if null</h2>
-<div class="jsoneditor" id="jsoneditor3"></div>
+<div class="jsoneditor" id="jsoneditor-schema-if-null"></div>
 
 <script>
   var schema = {
@@ -88,7 +88,6 @@
   };
   var company = {
     "title": "Company description",
-    // "type": "string"
     "$ref": "companyType"
   };
   var companyType = {
@@ -111,7 +110,6 @@
     schema: schema,
     schemaRefs: {"job": job, "company": company, "companyType": companyType},
     valueDisplayMode: 'value',
-    // valueDisplayModes: ['value','schema','schema-if-null'],
     onValueDisplayModeChange: function(mode) {
       console.log("onValueDisplayModeChange:", "'"+mode+"'");
     },
@@ -119,14 +117,13 @@
   };
 
   // create the editor
-  // options.valueDisplayMode = 'schema';
-  var container = document.getElementById('jsoneditor1');
-  var editor = new JSONEditor(container, options, json);
+  var editor = new JSONEditor(document.getElementById('jsoneditor-value'), options, json);
 
   options.valueDisplayMode = 'schema';
-  var editor2 = new JSONEditor(document.getElementById('jsoneditor2'), options, json);
+  var editor2 = new JSONEditor(document.getElementById('jsoneditor-schema'), options, json);
+  
   options.valueDisplayMode = 'schema-if-null';
-  var editor3 = new JSONEditor(document.getElementById('jsoneditor3'), options, json);
+  var editor3 = new JSONEditor(document.getElementById('jsoneditor-schema-if-null'), options, json);
 </script>
 </body>
 </html>

--- a/src/css/jsoneditor.css
+++ b/src/css/jsoneditor.css
@@ -118,6 +118,20 @@ div.jsoneditor-value.jsoneditor-null {
   color: #004ED0;
 }
 
+div.jsoneditor-value.jsoneditor-null.jsoneditor-expected-number,
+div.jsoneditor-value.jsoneditor-null.jsoneditor-expected-string,
+div.jsoneditor-value.jsoneditor-null.jsoneditor-expected-integer {
+  color: #ee422e;
+  font-style: italic;
+}
+
+div.jsoneditor-value.jsoneditor-expected-number,
+div.jsoneditor-value.jsoneditor-expected-string,
+div.jsoneditor-value.jsoneditor-expected-integer {
+  color: #008000;
+  font-style: italic;
+}
+
 div.jsoneditor-value.jsoneditor-invalid {
   color: #000000;
 }

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -1226,12 +1226,12 @@ Node.prototype._findSchemaRef = function (reference) {
           return this._findSchemaRef(ref.properties[this.field].$ref);
         }
       }
-      // console.warn("Could not find schema ref", reference);
+      // console.warn('Could not find schema ref', reference);
       return undefined;
     }
     return ref.type;
   }
-  console.warn("Schema ref %s undefined", reference);
+  console.warn('Schema ref %s undefined', reference);
   return undefined;
 };
 

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -1206,6 +1206,36 @@ Node.prototype._onChangeField = function () {
 };
 
 /**
+ * Find schema reference in the editor options (recursively if necessary)
+ * @private
+ * @param {string} [reference]  schema ref for which we're looking for the type
+ * @return {string} Returns the schema type for the schema ref
+ */
+Node.prototype._findSchemaRef = function (reference) {
+  var ref = this.editor.options.schemaRefs[reference];
+  if (ref) {
+    if (!ref.type && ref.$ref) {
+      return this._findSchemaRef(ref.$ref);
+    }
+    if (ref.type === 'object') {
+      if (ref.properties && ref.properties[this.field]) {
+        if (ref.properties[this.field].type) {
+          return ref.properties[this.field].type;
+        }
+        if (ref.properties[this.field].$ref) {
+          return this._findSchemaRef(ref.properties[this.field].$ref);
+        }
+      }
+      // console.warn("Could not find schema ref", reference);
+      return undefined;
+    }
+    return ref.type;
+  }
+  console.warn("Schema ref %s undefined", reference);
+  return undefined;
+};
+
+/**
  * Update dom value:
  * - the text color of the value, depending on the type of the value
  * - the height of the field, depending on the width
@@ -1217,12 +1247,23 @@ Node.prototype._updateDomValue = function () {
   if (domValue) {
     var classNames = ['jsoneditor-value'];
 
-
     // set text color depending on value type
     var value = this.value;
     var type = (this.type == 'auto') ? util.type(value) : this.type;
     var isUrl = type == 'string' && util.isUrl(value);
     classNames.push('jsoneditor-' + type);
+    if (this.schema && (this.editor.options.valueDisplayMode === 'schema' || this.editor.options.valueDisplayMode === 'schema-if-null')) {
+      if (type === 'null' || this.editor.options.valueDisplayMode === 'schema') {
+        var schemaType = this.schema.type;
+        if (!schemaType && this.schema.$ref) {
+          schemaType = this._findSchemaRef(this.schema.$ref);
+        }
+        if (schemaType) {
+          classNames.push('jsoneditor-expected-' + schemaType);
+          domValue.textContent = schemaType;
+        }
+      }
+    }
     if (isUrl) {
       classNames.push('jsoneditor-url');
     }


### PR DESCRIPTION
Added option 'valueDisplayMode' to choose what the node value of a tree should indicate. If set to 'value' (default) it displays the node value, as it used to do. If set to 'schema' and a schema has been defined in the options, it displays the schema type of the node. If set to 'schema-if-null', it only displays the schema type if the value of the node is null.