### PR TITLE
Add listeners to list (shadow) root instead of window,

### DIFF
--- a/src/js/ContextMenu.js
+++ b/src/js/ContextMenu.js
@@ -3,6 +3,14 @@
 var util = require('./util');
 
 /**
+ * Node.getRootNode shim
+ * @param  {Node} node node to check
+ * @return {Node}      node's rootNode or `window` if there is ShadowDOM is not supported.
+ */
+function getRootNode(node){
+    return node.getRootNode && node.getRootNode() || window;
+}
+/**
  * A context menu
  * @param {Object[]} items    Array containing the menu structure
  *                            TODO: describe structure
@@ -240,7 +248,7 @@ ContextMenu.prototype.show = function (anchor, contentWindow) {
   // create and attach event listeners
   var me = this;
   var list = this.dom.list;
-  var rootNode = list.getRootNode && list.getRootNode() || window;
+  var rootNode = getRootNode(list);
   this.eventListeners.mousedown = util.addEventListener(rootNode, 'mousedown', function (event) {
     // hide menu on click outside of the menu
     var target = event.target;
@@ -281,11 +289,12 @@ ContextMenu.prototype.hide = function () {
 
   // remove all event listeners
   // all event listeners are supposed to be attached to document.
+  var rootNode = getRootNode(this.dom.list);
   for (var name in this.eventListeners) {
     if (this.eventListeners.hasOwnProperty(name)) {
       var fn = this.eventListeners[name];
       if (fn) {
-        util.removeEventListener(window, name, fn);
+        util.removeEventListener(rootNode, name, fn);
       }
       delete this.eventListeners[name];
     }

--- a/src/js/ContextMenu.js
+++ b/src/js/ContextMenu.js
@@ -240,7 +240,8 @@ ContextMenu.prototype.show = function (anchor, contentWindow) {
   // create and attach event listeners
   var me = this;
   var list = this.dom.list;
-  this.eventListeners.mousedown = util.addEventListener(window, 'mousedown', function (event) {
+  var rootNode = list.getRootNode && list.getRootNode() || window;
+  this.eventListeners.mousedown = util.addEventListener(rootNode, 'mousedown', function (event) {
     // hide menu on click outside of the menu
     var target = event.target;
     if ((target != list) && !me._isChildOf(target, list)) {
@@ -249,7 +250,7 @@ ContextMenu.prototype.show = function (anchor, contentWindow) {
       event.preventDefault();
     }
   });
-  this.eventListeners.keydown = util.addEventListener(window, 'keydown', function (event) {
+  this.eventListeners.keydown = util.addEventListener(rootNode, 'keydown', function (event) {
     me._onKeyDown(event);
   });
 


### PR DESCRIPTION
make context menus work in Shadow DOM.

Fixes https://github.com/josdejong/jsoneditor/issues/447