### PR TITLE
Fix FindSchema for nested composites

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -2056,13 +2056,13 @@ Node._findSchema = function (schema, path) {
       if (typeof key === 'string' && childSchema.properties) {
         childSchema = childSchema.properties[key] || null;
         if (childSchema) {
-          foundSchema = childSchema;
+          foundSchema = Node._findSchema(childSchema, path.slice(i, path.length));
         }
       }
       else if (typeof key === 'number' && childSchema.items) {
         childSchema = childSchema.items;
         if (childSchema) {
-          foundSchema = childSchema;
+          foundSchema = Node._findSchema(childSchema, path.slice(i, path.length));
         }
       }
     }


### PR DESCRIPTION
Hi again,

Turns out my previous fix wasn't enough to handle cases of nested composites :/
Fiddle with the bug:
https://jsfiddle.net/59h2cobx/2/

Fiddle with the fix:
https://jsfiddle.net/59h2cobx/3/

It will still output the last schema that matches: see https://jsfiddle.net/59h2cobx/4/ and https://jsfiddle.net/59h2cobx/5/

Cheers!