### PR TITLE
Fix autocomplete.js encoding

### DIFF
--- a/src/js/autocomplete.js
+++ b/src/js/autocomplete.js
@@ -1,4 +1,4 @@
-﻿'use strict';
+'use strict';
 
 function completely(config) {
     config = config || {};


### PR DESCRIPTION
Hi! Thanks for the awesome editor. 

`autocomplete.js` encoding used to be `UTF-8 with BOM`, it should be `UTF-8`. Because of this my builds contain a BOM character that caused this:

![image](https://user-images.githubusercontent.com/17054134/33126174-de522040-cf83-11e7-8c11-4a926bd20bc3.png)

![image](https://user-images.githubusercontent.com/17054134/33126237-16b878d0-cf84-11e7-9944-27bc4621c05a.png)

Also, this is the only file that has this encoding in your library.
