### PR TITLE
In the View mode, open links in the same tab by default

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -2151,7 +2151,6 @@ Node.prototype._createDomValue = function () {
       // create a link in case of read-only editor and value containing an url
       domValue = document.createElement('a');
       domValue.href = this.value;
-      domValue.target = '_blank';
       domValue.innerHTML = this._escapeHTML(this.value);
     }
     else {


### PR DESCRIPTION
They'll still get opened in a new tab when the user presses Ctrl (like in the other modes).