### PR TITLE
cache parent errors

### DIFF
--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -435,6 +435,8 @@ treemode.validate = function () {
     }
   }
 
+  var parentErrors = [];
+
   // display the error in the nodes with a problem
   this.errorNodes = duplicateErrors
       .concat(schemaErrors)
@@ -443,7 +445,11 @@ treemode.validate = function () {
         // original entries last
         return entry.node
             .findParents()
+            .filter(function (parent) {
+              return parentErrors.indexOf(parent) === -1;
+            })
             .map(function (parent) {
+              parentErrors.push(parent);
               return {
                 node: parent,
                 child: entry.node,

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -436,23 +436,28 @@ treemode.validate = function () {
   }
 
   var errorNodes = duplicateErrors.concat(schemaErrors);
-  var parents = errorNodes
+  var parentPairs = errorNodes
       .reduce(function (all, entry) {
           return entry.node
               .findParents()
               .filter(function (parent) {
-                  return all.indexOf(parent) === -1;
+                  return !all.some(function (pair) {
+                    return pair[0] === parent;
+                  });
+              })
+              .map(function (parent) {
+                  return [parent, entry.node];
               })
               .concat(all);
       }, []);
 
-  this.errorNodes = parents
-      .map(function (parent) {
+  this.errorNodes = parentPairs
+      .map(function (pair) {
           return {
-            node: parent,
-            child: entry.node,
+            node: pair[0],
+            child: pair[1],
             error: {
-              message: parent.type === 'object'
+              message: pair[0].type === 'object'
                   ? 'Contains invalid properties' // object
                   : 'Contains invalid items'      // array
             }


### PR DESCRIPTION
There's a rather bad memory issue in the treemode functions.

Essentially, it is possible to have multiple errors on one node and multiple errors down a tree of nodes. This means we can end up in the situation where we append an error for the node's parents multiple times.

In cases where we have a large schema, a large amount of errors, we end up appending a huge amount of parent errors.

To combat this, i've gone ahead and added a cache which we check before adding an "invalid parent" error. 