### PR TITLE
allow null autocomplete results

### DIFF
--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -1216,13 +1216,18 @@ treemode._onKeyDown = function (event) {
           setTimeout(function (hnode, element) {
               if (element.innerText.length > 0) {
                   var result = this.options.autocomplete.getOptions(element.innerText, hnode.getPath(), jsonElementType, hnode.editor);
-                  if (typeof result.then === 'function') {
+                  if (result === null) {
+                      this.autocomplete.hideDropDown();
+                  } else if (typeof result.then === 'function') {
                       // probably a promise
                       if (result.then(function (obj) {
-                          if (obj.options)
+                          if (obj === null) {
+                              this.autocomplete.hideDropDown();
+                          } else if (obj.options) {
                               this.autocomplete.show(element, obj.startFrom, obj.options);
-                          else
+                          } else {
                               this.autocomplete.show(element, 0, obj);
+                          }
                       }.bind(this)));
                   } else {
                       // definitely not a promise


### PR DESCRIPTION
The docs state:

> Can return null when there are no autocomplete options.

so we should be able to:

```js
getOptions(text, path, input, editor) {
  return null;
}
```

or

```js
getOptions(text, path, input, editor) {
  return Promise.resolve(null);
}
```

However, we can't currently do this because the promise-check will throw an exception: `typeof result.then === 'function'` (`result` is null).