### PR TITLE
jsoneditor-icons.svg is explicitly in a relative path to be compliant…

### DIFF
--- a/src/css/contextmenu.css
+++ b/src/css/contextmenu.css
@@ -86,7 +86,7 @@ div.jsoneditor-contextmenu div.jsoneditor-icon {
   border: none;
   padding: 0;
   margin: 0;
-  background-image: url('img/jsoneditor-icons.svg');
+  background-image: url('./img/jsoneditor-icons.svg');
 }
 
 div.jsoneditor-contextmenu ul li ul div.jsoneditor-icon {
@@ -110,7 +110,7 @@ div.jsoneditor-contextmenu ul li button div.jsoneditor-expand {
   height: 24px;
   padding: 0;
   margin: 0 4px 0 0;
-  background: url('img/jsoneditor-icons.svg') 0 -72px;
+  background: url('./img/jsoneditor-icons.svg') 0 -72px;
   opacity: 0.4;
 }
 

--- a/src/css/jsoneditor.css
+++ b/src/css/jsoneditor.css
@@ -131,7 +131,7 @@ div.jsoneditor-tree button {
   margin: 0;
   border: none;
   cursor: pointer;
-  background: transparent url('img/jsoneditor-icons.svg');
+  background: transparent url('./img/jsoneditor-icons.svg');
 }
 
 div.jsoneditor-mode-view tr.jsoneditor-expandable td.jsoneditor-tree,
@@ -263,7 +263,7 @@ tr.jsoneditor-selected.jsoneditor-first button.jsoneditor-contextmenu {
 }
 
 div.jsoneditor-tree button.jsoneditor-dragarea {
-  background: url('img/jsoneditor-icons.svg') -72px -72px;
+  background: url('./img/jsoneditor-icons.svg') -72px -72px;
   cursor: move;
 }
 
@@ -320,7 +320,7 @@ div.jsoneditor-tree .jsoneditor-schema-error {
   height: 24px;
   padding: 0;
   margin: 0 4px 0 0;
-  background: url('img/jsoneditor-icons.svg')  -168px -48px;
+  background: url('./img/jsoneditor-icons.svg')  -168px -48px;
 }
 
 .jsoneditor-schema-error .jsoneditor-popover {
@@ -454,6 +454,6 @@ div.jsoneditor-tree .jsoneditor-schema-error {
   height: 24px;
   padding: 0;
   margin: 0 4px 0 0;
-  background: url('img/jsoneditor-icons.svg')  -168px -48px;
+  background: url('./img/jsoneditor-icons.svg')  -168px -48px;
 }
 

--- a/src/css/menu.css
+++ b/src/css/menu.css
@@ -21,7 +21,7 @@ div.jsoneditor-menu > div.jsoneditor-modes > button {
   padding: 0;
   border-radius: 2px;
   border: 1px solid transparent;
-  background: transparent url('img/jsoneditor-icons.svg');
+  background: transparent url('./img/jsoneditor-icons.svg');
   color: white;
   opacity: 0.8;
 

--- a/src/css/searchbox.css
+++ b/src/css/searchbox.css
@@ -46,7 +46,7 @@ table.jsoneditor-search button {
   padding: 0;
   margin: 0;
   border: none;
-  background: url('img/jsoneditor-icons.svg');
+  background: url('./img/jsoneditor-icons.svg');
   vertical-align: top;
 }
 


### PR DESCRIPTION
jsoneditor-icons.svg is explicitly in a relative path to be compliant with webpack plugin "file-loader"

file-loader is, actually, interpreting `img/jsoneditor-icons.svg` as absolute path. To ensure the path to be relative, just put `./`