### PR TITLE
Fix #582: parse error annotations not always up to date in code editor

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,11 @@
 
 https://github.com/josdejong/jsoneditor
 
+## not yet released, version 5.24.7
+
+- Fix #582: parse error annotations not always up to date in
+  code editor.
+
 
 ## 2018-09-12, version 5.24.6
 

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -531,7 +531,10 @@ textmode._emitSelectionChange = function () {
 }
 
 textmode._refreshAnnotations = function () {
-  this.aceEditor && this.aceEditor.getSession().setAnnotations();  
+  var session = this.aceEditor && this.aceEditor.getSession()
+  if (session) {
+    session.setAnnotations(session.getAnnotations())
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #582 

@meirotstein I think I may have found a solution for #582. I'm not sure though whether this may break other things, can you double check?