### PR TITLE
Show schema errors with unmapped locations in ace editor mode (#556)

### DIFF
--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -890,8 +890,12 @@ textmode._renderErrors = function(errors) {
         return {};
       });
       this._refreshAnnotations();
+    }
 
-    } else {
+    if (!this.aceEditor || errors.length !== errorLocations.length) {
+      if (this.aceEditor) {
+        errors = errors.filter(function(err) { return !errorLocations.some(function (errLoc) { return errLoc.path === err.dataPath })});
+      }
       var validationErrors = document.createElement('div');
       validationErrors.innerHTML = '<table class="jsoneditor-text-errors"><tbody></tbody></table>';
       var tbody = validationErrors.getElementsByTagName('tbody')[0];


### PR DESCRIPTION
This PR changes the display of schema/custom errors in "code" view.

Any errors that do not have a valid path are now shown in the `jsoneditor-text-errors` table at the bottom of the editor area.