### PR TITLE
 i18n for ModeSwitcher

### DIFF
--- a/src/js/ModeSwitcher.js
+++ b/src/js/ModeSwitcher.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var ContextMenu = require('./ContextMenu');
+var translate = require('./i18n').translate;
 
 /**
  * Create a select box to be used in the editor menu's, which allows to switch mode
@@ -14,36 +15,36 @@ function ModeSwitcher(container, modes, current, onSwitch) {
   // available modes
   var availableModes = {
     code: {
-      'text': 'Code',
-      'title': 'Switch to code highlighter',
+      'text': translate('modeCodeText'),
+      'title': translate('modeCodeTitle'),
       'click': function () {
         onSwitch('code')
       }
     },
     form: {
-      'text': 'Form',
-      'title': 'Switch to form editor',
+      'text': translate('modeFormText'),
+      'title': translate('modeFormTitle'),
       'click': function () {
         onSwitch('form');
       }
     },
     text: {
-      'text': 'Text',
-      'title': 'Switch to plain text editor',
+      'text': translate('modeTextText'),
+      'title': translate('modeTextTitle'),
       'click': function () {
         onSwitch('text');
       }
     },
     tree: {
-      'text': 'Tree',
-      'title': 'Switch to tree editor',
+      'text': translate('modeTreeText'),
+      'title': translate('modeTreeTitle'),
       'click': function () {
         onSwitch('tree');
       }
     },
     view: {
-      'text': 'View',
-      'title': 'Switch to tree view',
+      'text': translate('modeViewText'),
+      'title': translate('modeViewTitle'),
       'click': function () {
         onSwitch('view');
       }

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -73,6 +73,16 @@ var _defs = {
     stringType: 'Field type "string". ' +
       'Field type is not determined from the value, ' +
       'but always returned as string.',
+    modeCodeText: 'Code',
+    modeCodeTitle: 'Switch to code highlighter',
+    modeFormText: 'Form',
+    modeFormTitle: 'Switch to form editor',
+    modeTextText: 'Text',
+    modeTextTitle: 'Switch to plain text editor',
+    modeTreeText: 'Tree',
+    modeTreeTitle: 'Switch to tree editor',
+    modeViewText: 'View',
+    modeViewTitle: 'Switch to tree view',
   },
   'pt-BR': {
     array: 'Lista',

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -3,178 +3,178 @@
 var _locales = ['en', 'pt-BR'];
 var _defs = {
   en: {
-    'array': 'Array',
-    'auto': 'Auto',
-    'appendText': 'Append',
-    'appendTitle': 'Append a new field with type \'auto\' after this field (Ctrl+Shift+Ins)',
-    'appendSubmenuTitle': 'Select the type of the field to be appended',
-    'appendTitleAuto': 'Append a new field with type \'auto\' (Ctrl+Shift+Ins)',
-    'ascending': 'Ascending',
-    'ascendingTitle': 'Sort the childs of this ${type} in ascending order',
-    'actionsMenu': 'Click to open the actions menu (Ctrl+M)',
-    'collapseAll': 'Collapse all fields',
-    'descending': 'Descending',
-    'descendingTitle': 'Sort the childs of this ${type} in descending order',
-    'drag': 'Drag to move this field (Alt+Shift+Arrows)',
-    'duplicateKey': 'duplicate key',
-    'duplicateText': 'Duplicate',
-    'duplicateTitle': 'Duplicate selected fields (Ctrl+D)',
-    'duplicateField': 'Duplicate this field (Ctrl+D)',
-    'empty': 'empty',
-    'expandAll': 'Expand all fields',
-    'expandTitle': 'Click to expand/collapse this field (Ctrl+E). \n' +
-    'Ctrl+Click to expand/collapse including all childs.',
-    'insert': 'Insert',
-    'insertTitle': 'Insert a new field with type \'auto\' before this field (Ctrl+Ins)',
-    'insertSub': 'Select the type of the field to be inserted',
-    'object': 'Object',
-    'ok': 'Ok',
-    'redo': 'Redo (Ctrl+Shift+Z)',
-    'removeText': 'Remove',
-    'removeTitle': 'Remove selected fields (Ctrl+Del)',
-    'removeField': 'Remove this field (Ctrl+Del)',
-    'selectNode': 'Select a node...',
-    'showAll': 'show all',
-    'showMore': 'show more',
-    'showMoreStatus': 'displaying ${visibleChilds} of ${totalChilds} items.',
-    'sort': 'Sort',
-    'sortTitle': 'Sort the childs of this ${type}',
-    'sortTitleShort': 'Sort contents',
-    'sortFieldLabel': 'Field:',
-    'sortDirectionLabel': 'Direction:',
-    'sortFieldTitle': 'Select the nested field by which to sort the array or object',
-    'sortAscending': 'Ascending',
-    'sortAscendingTitle': 'Sort the selected field in ascending order',
-    'sortDescending': 'Descending',
-    'sortDescendingTitle': 'Sort the selected field in descending order',
-    'string': 'String',
-    'transform': 'Transform',
-    'transformTitle': 'Filter, sort, or transform the childs of this ${type}',
-    'transformTitleShort': 'Filter, sort, or transform contents',
-    'transformQueryTitle': 'Enter a JMESPath query',
-    'transformWizardLabel': 'Wizard',
-    'transformWizardFilter': 'Filter',
-    'transformWizardSortBy': 'Sort by',
-    'transformWizardSelectFields': 'Select fields',
-    'transformQueryLabel': 'Query',
-    'transformPreviewLabel': 'Preview',
-    'type': 'Type',
-    'typeTitle': 'Change the type of this field',
-    'openUrl': 'Ctrl+Click or Ctrl+Enter to open url in new window',
-    'undo': 'Undo last action (Ctrl+Z)',
-    'validationCannotMove': 'Cannot move a field into a child of itself',
-    'autoType': 'Field type "auto". ' +
-    'The field type is automatically determined from the value ' +
-    'and can be a string, number, boolean, or null.',
-    'objectType': 'Field type "object". ' +
-    'An object contains an unordered set of key/value pairs.',
-    'arrayType': 'Field type "array". ' +
-    'An array contains an ordered collection of values.',
-    'stringType': 'Field type "string". ' +
-    'Field type is not determined from the value, ' +
-    'but always returned as string.'
+    array: 'Array',
+    auto: 'Auto',
+    appendText: 'Append',
+    appendTitle: 'Append a new field with type \'auto\' after this field (Ctrl+Shift+Ins)',
+    appendSubmenuTitle: 'Select the type of the field to be appended',
+    appendTitleAuto: 'Append a new field with type \'auto\' (Ctrl+Shift+Ins)',
+    ascending: 'Ascending',
+    ascendingTitle: 'Sort the childs of this ${type} in ascending order',
+    actionsMenu: 'Click to open the actions menu (Ctrl+M)',
+    collapseAll: 'Collapse all fields',
+    descending: 'Descending',
+    descendingTitle: 'Sort the childs of this ${type} in descending order',
+    drag: 'Drag to move this field (Alt+Shift+Arrows)',
+    duplicateKey: 'duplicate key',
+    duplicateText: 'Duplicate',
+    duplicateTitle: 'Duplicate selected fields (Ctrl+D)',
+    duplicateField: 'Duplicate this field (Ctrl+D)',
+    empty: 'empty',
+    expandAll: 'Expand all fields',
+    expandTitle: 'Click to expand/collapse this field (Ctrl+E). \n' +
+      'Ctrl+Click to expand/collapse including all childs.',
+    insert: 'Insert',
+    insertTitle: 'Insert a new field with type \'auto\' before this field (Ctrl+Ins)',
+    insertSub: 'Select the type of the field to be inserted',
+    object: 'Object',
+    ok: 'Ok',
+    redo: 'Redo (Ctrl+Shift+Z)',
+    removeText: 'Remove',
+    removeTitle: 'Remove selected fields (Ctrl+Del)',
+    removeField: 'Remove this field (Ctrl+Del)',
+    selectNode: 'Select a node...',
+    showAll: 'show all',
+    showMore: 'show more',
+    showMoreStatus: 'displaying ${visibleChilds} of ${totalChilds} items.',
+    sort: 'Sort',
+    sortTitle: 'Sort the childs of this ${type}',
+    sortTitleShort: 'Sort contents',
+    sortFieldLabel: 'Field:',
+    sortDirectionLabel: 'Direction:',
+    sortFieldTitle: 'Select the nested field by which to sort the array or object',
+    sortAscending: 'Ascending',
+    sortAscendingTitle: 'Sort the selected field in ascending order',
+    sortDescending: 'Descending',
+    sortDescendingTitle: 'Sort the selected field in descending order',
+    string: 'String',
+    transform: 'Transform',
+    transformTitle: 'Filter, sort, or transform the childs of this ${type}',
+    transformTitleShort: 'Filter, sort, or transform contents',
+    transformQueryTitle: 'Enter a JMESPath query',
+    transformWizardLabel: 'Wizard',
+    transformWizardFilter: 'Filter',
+    transformWizardSortBy: 'Sort by',
+    transformWizardSelectFields: 'Select fields',
+    transformQueryLabel: 'Query',
+    transformPreviewLabel: 'Preview',
+    type: 'Type',
+    typeTitle: 'Change the type of this field',
+    openUrl: 'Ctrl+Click or Ctrl+Enter to open url in new window',
+    undo: 'Undo last action (Ctrl+Z)',
+    validationCannotMove: 'Cannot move a field into a child of itself',
+    autoType: 'Field type "auto". ' +
+      'The field type is automatically determined from the value ' +
+      'and can be a string, number, boolean, or null.',
+    objectType: 'Field type "object". ' +
+      'An object contains an unordered set of key/value pairs.',
+    arrayType: 'Field type "array". ' +
+      'An array contains an ordered collection of values.',
+    stringType: 'Field type "string". ' +
+      'Field type is not determined from the value, ' +
+      'but always returned as string.',
   },
   'pt-BR': {
-    'array': 'Lista',
-    'auto': 'Automatico',
-    'appendText': 'Adicionar',
-    'appendTitle': 'Adicionar novo campo com tipo \'auto\' depois deste campo (Ctrl+Shift+Ins)',
-    'appendSubmenuTitle': 'Selecione o tipo do campo a ser adicionado',
-    'appendTitleAuto': 'Adicionar novo campo com tipo \'auto\' (Ctrl+Shift+Ins)',
-    'ascending': 'Ascendente',
-    'ascendingTitle': 'Organizar filhor do tipo ${type} em crescente',
-    'actionsMenu': 'Clique para abrir o menu de ações (Ctrl+M)',
-    'collapseAll': 'Fechar todos campos',
-    'descending': 'Descendente',
-    'descendingTitle': 'Organizar o filhos do tipo ${type} em decrescente',
-    'duplicateKey': 'chave duplicada',
-    'drag': 'Arraste para mover este campo (Alt+Shift+Arrows)',
-    'duplicateText': 'Duplicar',
-    'duplicateTitle': 'Duplicar campos selecionados (Ctrl+D)',
-    'duplicateField': 'Duplicar este campo (Ctrl+D)',
-    'empty': 'vazio',
-    'expandAll': 'Expandir todos campos',
-    'expandTitle': 'Clique para expandir/encolher este campo (Ctrl+E). \n' +
-    'Ctrl+Click para expandir/encolher incluindo todos os filhos.',
-    'insert': 'Inserir',
-    'insertTitle': 'Inserir um novo campo do tipo \'auto\' antes deste campo (Ctrl+Ins)',
-    'insertSub': 'Selecionar o tipo de campo a ser inserido',
-    'object': 'Objeto',
-    'ok': 'Ok',
-    'redo': 'Refazer (Ctrl+Shift+Z)',
-    'removeText': 'Remover',
-    'removeTitle': 'Remover campos selecionados (Ctrl+Del)',
-    'removeField': 'Remover este campo (Ctrl+Del)',
+    array: 'Lista',
+    auto: 'Automatico',
+    appendText: 'Adicionar',
+    appendTitle: 'Adicionar novo campo com tipo \'auto\' depois deste campo (Ctrl+Shift+Ins)',
+    appendSubmenuTitle: 'Selecione o tipo do campo a ser adicionado',
+    appendTitleAuto: 'Adicionar novo campo com tipo \'auto\' (Ctrl+Shift+Ins)',
+    ascending: 'Ascendente',
+    ascendingTitle: 'Organizar filhor do tipo ${type} em crescente',
+    actionsMenu: 'Clique para abrir o menu de ações (Ctrl+M)',
+    collapseAll: 'Fechar todos campos',
+    descending: 'Descendente',
+    descendingTitle: 'Organizar o filhos do tipo ${type} em decrescente',
+    duplicateKey: 'chave duplicada',
+    drag: 'Arraste para mover este campo (Alt+Shift+Arrows)',
+    duplicateText: 'Duplicar',
+    duplicateTitle: 'Duplicar campos selecionados (Ctrl+D)',
+    duplicateField: 'Duplicar este campo (Ctrl+D)',
+    empty: 'vazio',
+    expandAll: 'Expandir todos campos',
+    expandTitle: 'Clique para expandir/encolher este campo (Ctrl+E). \n' +
+      'Ctrl+Click para expandir/encolher incluindo todos os filhos.',
+    insert: 'Inserir',
+    insertTitle: 'Inserir um novo campo do tipo \'auto\' antes deste campo (Ctrl+Ins)',
+    insertSub: 'Selecionar o tipo de campo a ser inserido',
+    object: 'Objeto',
+    ok: 'Ok',
+    redo: 'Refazer (Ctrl+Shift+Z)',
+    removeText: 'Remover',
+    removeTitle: 'Remover campos selecionados (Ctrl+Del)',
+    removeField: 'Remover este campo (Ctrl+Del)',
     // TODO: correctly translate
-    'selectNode': 'Select a node...',
+    selectNode: 'Select a node...',
     // TODO: correctly translate
-    'showAll': 'mostre tudo',
+    showAll: 'mostre tudo',
     // TODO: correctly translate
-    'showMore': 'mostre mais',
+    showMore: 'mostre mais',
     // TODO: correctly translate
-    'showMoreStatus': 'exibindo ${visibleChilds} de ${totalChilds} itens.',
-    'sort': 'Organizar',
-    'sortTitle': 'Organizar os filhos deste ${type}',
+    showMoreStatus: 'exibindo ${visibleChilds} de ${totalChilds} itens.',
+    sort: 'Organizar',
+    sortTitle: 'Organizar os filhos deste ${type}',
     // TODO: correctly translate
-    'sortTitleShort': 'Organizar os filhos',
+    sortTitleShort: 'Organizar os filhos',
     // TODO: correctly translate
-    'sortFieldLabel': 'Field:',
+    sortFieldLabel: 'Field:',
     // TODO: correctly translate
-    'sortDirectionLabel': 'Direction:',
+    sortDirectionLabel: 'Direction:',
     // TODO: correctly translate
-    'sortFieldTitle': 'Select the nested field by which to sort the array or object',
+    sortFieldTitle: 'Select the nested field by which to sort the array or object',
     // TODO: correctly translate
-    'sortAscending': 'Ascending',
+    sortAscending: 'Ascending',
     // TODO: correctly translate
-    'sortAscendingTitle': 'Sort the selected field in ascending order',
+    sortAscendingTitle: 'Sort the selected field in ascending order',
     // TODO: correctly translate
-    'sortDescending': 'Descending',
+    sortDescending: 'Descending',
     // TODO: correctly translate
-    'sortDescendingTitle': 'Sort the selected field in descending order',
-    'string': 'Texto',
+    sortDescendingTitle: 'Sort the selected field in descending order',
+    string: 'Texto',
     // TODO: correctly translate
-    'transform': 'Transform',
+    transform: 'Transform',
     // TODO: correctly translate
-    'transformTitle': 'Filter, sort, or transform the childs of this ${type}',
+    transformTitle: 'Filter, sort, or transform the childs of this ${type}',
     // TODO: correctly translate
-    'transformTitleShort': 'Filter, sort, or transform contents',
+    transformTitleShort: 'Filter, sort, or transform contents',
     // TODO: correctly translate
-    'transformQueryTitle': 'Enter a JMESPath query',
+    transformQueryTitle: 'Enter a JMESPath query',
     // TODO: correctly translate
-    'transformWizardLabel': 'Wizard',
+    transformWizardLabel: 'Wizard',
     // TODO: correctly translate
-    'transformWizardFilter': 'Filter',
+    transformWizardFilter: 'Filter',
     // TODO: correctly translate
-    'transformWizardSortBy': 'Sort by',
+    transformWizardSortBy: 'Sort by',
     // TODO: correctly translate
-    'transformWizardSelectFields': 'Select fields',
+    transformWizardSelectFields: 'Select fields',
     // TODO: correctly translate
-    'transformQueryLabel': 'Query',
+    transformQueryLabel: 'Query',
     // TODO: correctly translate
-    'transformPreviewLabel': 'Preview',
-    'type': 'Tipo',
-    'typeTitle': 'Mudar o tipo deste campo',
-    'openUrl': 'Ctrl+Click ou Ctrl+Enter para abrir link em nova janela',
-    'undo': 'Desfazer último ação (Ctrl+Z)',
-    'validationCannotMove': 'Não pode mover um campo como filho dele mesmo',
-    'autoType': 'Campo do tipo "auto". ' +
-    'O tipo do campo é determinao automaticamente a partir do seu valor ' +
-    'e pode ser texto, número, verdade/falso ou nulo.',
-    'objectType': 'Campo do tipo "objeto". ' +
-    'Um objeto contém uma lista de pares com chave e valor.',
-    'arrayType': 'Campo do tipo "lista". ' +
-    'Uma lista contem uma coleção de valores ordenados.',
-    'stringType': 'Campo do tipo "string". ' +
-    'Campo do tipo nao é determinado através do seu valor, ' +
-    'mas sempre retornara um texto.'
+    transformPreviewLabel: 'Preview',
+    type: 'Tipo',
+    typeTitle: 'Mudar o tipo deste campo',
+    openUrl: 'Ctrl+Click ou Ctrl+Enter para abrir link em nova janela',
+    undo: 'Desfazer último ação (Ctrl+Z)',
+    validationCannotMove: 'Não pode mover um campo como filho dele mesmo',
+    autoType: 'Campo do tipo "auto". ' +
+      'O tipo do campo é determinao automaticamente a partir do seu valor ' +
+      'e pode ser texto, número, verdade/falso ou nulo.',
+    objectType: 'Campo do tipo "objeto". ' +
+      'Um objeto contém uma lista de pares com chave e valor.',
+    arrayType: 'Campo do tipo "lista". ' +
+      'Uma lista contem uma coleção de valores ordenados.',
+    stringType: 'Campo do tipo "string". ' +
+      'Campo do tipo nao é determinado através do seu valor, ' +
+      'mas sempre retornara um texto.'
   }
 };
 
 var _defaultLang = 'en';
 var _lang;
-var userLang = typeof navigator !== 'undefined'
-    ? navigator.language || navigator.userLanguage
-    : undefined;
+var userLang = typeof navigator !== 'undefined' ?
+  navigator.language || navigator.userLanguage :
+  undefined;
 _lang = _locales.find(function (l) {
   return l === userLang;
 });


### PR DESCRIPTION
The **ModeSwitch**'s text was hard coded. This PR fixed it.

https://github.com/josdejong/jsoneditor/blob/72ab51002c27381474522d4090de5ed0ad3c237f/src/js/ModeSwitcher.js#L17-L46

*Other change:*
**Unquoted** i18n keys and fixed multiple lines' indent. For better readability.

Before:
![image](https://user-images.githubusercontent.com/11247099/50129530-4d8d8580-02b4-11e9-83b3-c2d3c44e75e4.png)

After:
![image](https://user-images.githubusercontent.com/11247099/50129518-35b60180-02b4-11e9-8aaa-7aa5cd82d005.png)
