### PR TITLE
Hide show error table

### DIFF
--- a/src/css/statusbar.css
+++ b/src/css/statusbar.css
@@ -29,6 +29,7 @@ div.jsoneditor-statusbar > .jsoneditor-validation-error-icon {
   padding: 0;
   margin-top: 1px;
   background: url("img/jsoneditor-icons.svg") -168px -48px;
+  cursor: pointer;
 }
 div.jsoneditor-statusbar > .jsoneditor-validation-error-count {
   float: right;

--- a/src/css/statusbar.css
+++ b/src/css/statusbar.css
@@ -34,6 +34,7 @@ div.jsoneditor-statusbar > .jsoneditor-validation-error-icon {
 div.jsoneditor-statusbar > .jsoneditor-validation-error-count {
   float: right;
   margin: 0 4px 0 0;
+  cursor: pointer;
 }
 div.jsoneditor-statusbar > .jsoneditor-parse-error-icon {
   float: right;

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -95,6 +95,11 @@ textmode.create = function (container, options) {
   this.validateSchema = null;
   this.validationSequence = 0;
   this.annotations = [];
+  /**
+   * Visibility of validation error table
+   * @type {Boolean|undefined} undefined means default behavior for mode
+   */
+  this.errorTableVisible = undefined;
 
   // create a debounced validate function
   this._debouncedValidate = util.debounce(this.validate.bind(this), this.DEBOUNCE_INTERVAL);
@@ -851,6 +856,7 @@ textmode._renderErrors = function(errors) {
   // clear all current errors
   var me = this;
   var validationErrorsCount = 0;
+  this.errorTableVisible = (typeof this.errorTableVisible === 'undefined') ? !this.aceEditor : this.errorTableVisible;
 
   if (this.dom.validationErrors) {
     this.dom.validationErrors.parentNode.removeChild(this.dom.validationErrors);
@@ -891,8 +897,10 @@ textmode._renderErrors = function(errors) {
       });
       this._refreshAnnotations();
 
-    } else {
-      var validationErrors = document.createElement('div');
+    }
+
+    if (this.errorTableVisible) {
+       var validationErrors = document.createElement('div');
       validationErrors.innerHTML = '<table class="jsoneditor-text-errors"><tbody></tbody></table>';
       var tbody = validationErrors.getElementsByTagName('tbody')[0];
 
@@ -955,7 +963,10 @@ textmode._renderErrors = function(errors) {
       var height = this.dom.validationErrorsContainer.clientHeight + (this.dom.statusBar ? this.dom.statusBar.clientHeight : 0);
       this.content.style.marginBottom = (-height) + 'px';
       this.content.style.paddingBottom = height + 'px';
+    } else {
+      validationErrorsCount = errors.reduce((acc, curr)=>{return (curr.type === 'validation' ? ++acc: acc)}, 0);
     }
+    
   } else {
     if (this.aceEditor) {
       this.annotations = [];
@@ -971,6 +982,7 @@ textmode._renderErrors = function(errors) {
     if (showIndication) {
       this.validationErrorIndication.validationErrorCount.innerText = validationErrorsCount;
       this.validationErrorIndication.validationErrorIcon.title = validationErrorsCount + ' schema validation error(s) found';
+      this.validationErrorIndication.validationErrorIcon.onclick = this._toggleErrorTableVisibility.bind(this);
     }
   }
 
@@ -979,6 +991,11 @@ textmode._renderErrors = function(errors) {
     var force = false;
     this.aceEditor.resize(force);
   }
+};
+
+textmode._toggleErrorTableVisibility = function () {
+  this.errorTableVisible = !this.errorTableVisible;
+  this.validate();
 };
 
 /**
@@ -1085,6 +1102,7 @@ textmode.setTextSelection = function (startPos, endPos) {
       }
     };
     this.aceEditor.selection.setRange(range);
+    // this.aceEditor.scrollToLine(startPos.row - 1);
   }
 };
 

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -966,7 +966,7 @@ textmode._renderErrors = function(errors, noValidation) {
       this.content.style.marginBottom = (-height) + 'px';
       this.content.style.paddingBottom = height + 'px';
     } else {
-      validationErrorsCount = errors.reduce((acc, curr)=>{return (curr.type === 'validation' ? ++acc: acc)}, 0);
+      validationErrorsCount = errors.reduce(function (acc, curr) {return (curr.type === 'validation' ? ++acc: acc)}, 0);
     }
     
   } else {

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -1102,7 +1102,7 @@ textmode.setTextSelection = function (startPos, endPos) {
       }
     };
     this.aceEditor.selection.setRange(range);
-    // this.aceEditor.scrollToLine(startPos.row - 1);
+    this.aceEditor.scrollToLine(startPos.row - 1, true);
   }
 };
 

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -799,7 +799,7 @@ textmode.validate = function () {
     }
   }
   else {
-    this._renderErrors(parseErrors || []);
+    this._renderErrors(parseErrors || [], true);
   }
 };
 
@@ -852,10 +852,11 @@ textmode._validateCustom = function (json) {
   return Promise.resolve(null);
 };
 
-textmode._renderErrors = function(errors) {
+textmode._renderErrors = function(errors, noValidation) {
   // clear all current errors
   var me = this;
   var validationErrorsCount = 0;
+
   this.errorTableVisible = (typeof this.errorTableVisible === 'undefined') ? !this.aceEditor : this.errorTableVisible;
 
   if (this.dom.validationErrors) {
@@ -899,7 +900,8 @@ textmode._renderErrors = function(errors) {
 
     }
 
-    if (this.errorTableVisible) {
+    // keep default behavior for parse errors
+    if (noValidation ? !this.aceEditor : this.errorTableVisible) {
        var validationErrors = document.createElement('div');
       validationErrors.innerHTML = '<table class="jsoneditor-text-errors"><tbody></tbody></table>';
       var tbody = validationErrors.getElementsByTagName('tbody')[0];
@@ -982,7 +984,7 @@ textmode._renderErrors = function(errors) {
     if (showIndication) {
       this.validationErrorIndication.validationErrorCount.innerText = validationErrorsCount;
       this.validationErrorIndication.validationErrorIcon.title = validationErrorsCount + ' schema validation error(s) found';
-      this.validationErrorIndication.validationErrorIcon.onclick = this._toggleErrorTableVisibility.bind(this);
+      this.validationErrorIndication.validationErrorCount.onclick = this.validationErrorIndication.validationErrorIcon.onclick = this._toggleErrorTableVisibility.bind(this);
     }
   }
 


### PR DESCRIPTION
As discussed in #606 (and on another issue that I can't find :smiley: ) - this PR allows toggling the visibility of the validation error tables for text and code mode
default behavior remains the same: visible for text mode, hidden for code mode.