### PR TITLE
Configurable max visible childs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -416,6 +416,10 @@ Constructs a new JSONEditor.
 
   Enable filtering, sorting, and transforming JSON using a [JMESPath](http://jmespath.org/) query. Only applicable for mode 'tree'. True by default.
 
+- `{Number} maxVisibleChilds`
+
+  Number of children allowed for a given node before the "show more / show all" message appears (in 'tree', 'view', or 'form' modes). 100 by default.
+
 ### Methods
 
 #### `JSONEditor.collapseAll()`

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -82,6 +82,11 @@ if (typeof Promise === 'undefined') {
  *                                                  Only applicable for
  *                                                  modes 'form', 'tree' and
  *                                                  'view'
+ *                               {Number} maxVisibleChilds Number of children allowed for a node 
+ *                                                         in 'tree', 'view', or 'form' mode before 
+ *                                                         the "show more/show all" buttons appear.  
+ *                                                         100 by default.
+ *
  * @param {Object | undefined} json JSON object
  */
 function JSONEditor (container, options, json) {
@@ -167,7 +172,8 @@ JSONEditor.VALID_OPTIONS = [
   'colorPicker', 'onColorPicker',
   'timestampTag',
   'escapeUnicode', 'history', 'search', 'mode', 'modes', 'name', 'indentation',
-  'sortObjectKeys', 'navigationBar', 'statusBar', 'mainMenuBar', 'languages', 'language', 'enableSort', 'enableTransform'
+  'sortObjectKeys', 'navigationBar', 'statusBar', 'mainMenuBar', 'languages', 'language', 'enableSort', 'enableTransform',
+  'maxVisibleChilds'
 ];
 
 /**

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -56,11 +56,14 @@ Node.prototype.DEBOUNCE_INTERVAL = 150;
 // search will stop iterating as soon as the max is reached
 Node.prototype.MAX_SEARCH_RESULTS = 999;
 
-// number of visible childs rendered initially in large arrays/objects (with a "show more" button to show more)
-Node.prototype.MAX_VISIBLE_CHILDS = 100;
+// default number of child nodes to display 
+var DEFAULT_MAX_VISIBLE_CHILDS = 100;
 
-// default value for the max visible childs of large arrays
-Node.prototype.visibleChilds = Node.prototype.MAX_VISIBLE_CHILDS;
+Node.prototype.getMaxVisibleChilds = function() {
+  return (this.editor && this.editor.options && this.editor.options.maxVisibleChilds)
+      ? this.editor.options.maxVisibleChilds
+      : DEFAULT_MAX_VISIBLE_CHILDS;
+}
 
 /**
  * Determine whether the field and/or value of this node are editable
@@ -94,6 +97,9 @@ Node.prototype._updateEditability = function () {
       }
     }
   }
+
+  // default value for the max visible children of large arrays
+  Node.prototype.visibleChilds = this.getMaxVisibleChilds();
 };
 
 /**
@@ -425,7 +431,7 @@ Node.prototype.setValue = function(value, type) {
           child = new Node(this.editor, {
             value: childValue
           });
-          visible = i < this.MAX_VISIBLE_CHILDS;
+          visible = i < this.getMaxVisibleChilds();
           this.appendChild(child, visible, notUpdateDom);
         }
       }
@@ -469,7 +475,7 @@ Node.prototype.setValue = function(value, type) {
               field: childField,
               value: childValue
             });
-            visible = i < this.MAX_VISIBLE_CHILDS;
+            visible = i < this.getMaxVisibleChilds();
             this.appendChild(child, visible, notUpdateDom);
           }
         }
@@ -542,7 +548,7 @@ Node.prototype.setInternalValue = function(internalValue) {
           child = new Node(this.editor, {
             internalValue: childValue
           });
-          visible = i < this.MAX_VISIBLE_CHILDS;
+          visible = i < this.getMaxVisibleChilds();
           this.appendChild(child, visible, notUpdateDom);
         }
       }
@@ -577,7 +583,7 @@ Node.prototype.setInternalValue = function(internalValue) {
             field: childValue.field,
             internalValue: childValue.value
           });
-          visible = i < this.MAX_VISIBLE_CHILDS;
+          visible = i < this.getMaxVisibleChilds();
           this.appendChild(child, visible, notUpdateDom);
         }
       }
@@ -1173,7 +1179,7 @@ Node.prototype.expandPathToNode = function () {
         ? node.index
         : node.parent.childs.indexOf(node);
     while (node.parent.visibleChilds < index + 1) {
-      node.parent.visibleChilds += Node.prototype.MAX_VISIBLE_CHILDS;
+      node.parent.visibleChilds += this.getMaxVisibleChilds();
     }
 
     // expand the parent itself

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -48,6 +48,8 @@ function Node (editor, params) {
 
   this._debouncedOnChangeValue = util.debounce(this._onChangeValue.bind(this), Node.prototype.DEBOUNCE_INTERVAL);
   this._debouncedOnChangeField = util.debounce(this._onChangeField.bind(this), Node.prototype.DEBOUNCE_INTERVAL);
+  // starting value for visible children
+  this.visibleChilds = this.getMaxVisibleChilds();
 }
 
 // debounce interval for keyboard input in milliseconds
@@ -97,9 +99,6 @@ Node.prototype._updateEditability = function () {
       }
     }
   }
-
-  // default value for the max visible children of large arrays
-  Node.prototype.visibleChilds = this.getMaxVisibleChilds();
 };
 
 /**

--- a/src/js/showMoreNodeFactory.js
+++ b/src/js/showMoreNodeFactory.js
@@ -44,8 +44,8 @@ function showMoreNodeFactory(Node) {
       showMoreButton.href = '#';
       showMoreButton.onclick = function (event) {
         // TODO: use callback instead of accessing a method of the parent
-        parent.visibleChilds = Math.floor(parent.visibleChilds / parent.MAX_VISIBLE_CHILDS + 1) *
-            parent.MAX_VISIBLE_CHILDS;
+        parent.visibleChilds = Math.floor(parent.visibleChilds / parent.getMaxVisibleChilds() + 1) *
+            parent.getMaxVisibleChilds();
         me.updateDom();
         parent.showChilds();
 


### PR DESCRIPTION
Adds a "maxVisibleChilds" option that allows the user to set the number of nodes visible in the tree before the "show more / show all" message appears. The default remains 100.