### PR TITLE
Allow enum with blank value as valid output by schema

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -185,6 +185,12 @@ Constructs a new JSONEditor.
   Schemas that are referenced using the `$ref` property from the JSON schema that are set in the `schema` option,
   the object structure in the form of `{reference_key: schemaObject}`
 
+- `{String | null} enumDefaultValue`
+
+  Set default blank option value for `enum` lists in schema. `""` by default.
+  
+  If `enum` list contains the blank value, it will still be rendered as the frst option with title '--', but will be valid according to schema.
+
 - `{boolean} search`
 
   Enables a search box in the upper right corner of the JSONEditor. True by default. Only applicable when `mode` is 'tree', 'view', or 'form'.

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -170,7 +170,7 @@ JSONEditor.modes = {};
 JSONEditor.prototype.DEBOUNCE_INTERVAL = 150;
 
 JSONEditor.VALID_OPTIONS = [
-  'ajv', 'schema', 'schemaRefs','templates',
+  'ajv', 'schema', 'schemaRefs','templates', 'enumDefaultValue',
   'ace', 'theme', 'autocomplete',
   'onChange', 'onChangeJSON', 'onChangeText',
   'onEditable', 'onError', 'onEvent', 'onModeChange', 'onNodeName', 'onValidate',

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -1714,6 +1714,9 @@ Node.prototype._updateDomValue = function () {
 
     // create select box when this node has an enum object
     if (this.enum && this.editable.value) {
+      // The default blank value in enum list can be changed with 'enumDefaultValue' option.
+      var enumDefaultValue = 'enumDefaultValue' in this.editor.options ? this.editor.options.enumDefaultValue : '';
+
       if (!this.dom.select) {
         this.dom.select = document.createElement('select');
         this.id = this.field + "_" + new Date().getUTCMilliseconds();
@@ -1722,12 +1725,19 @@ Node.prototype._updateDomValue = function () {
 
         //Create the default empty option
         this.dom.select.option = document.createElement('option');
-        this.dom.select.option.value = '';
+        this.dom.select.option.value = enumDefaultValue;
         this.dom.select.option.innerHTML = '--';
         this.dom.select.appendChild(this.dom.select.option);
 
         //Iterate all enum values and add them as options
         for(var i = 0; i < this.enum.length; i++) {
+
+          // If enum list in schema contains the default blank value as allowed return value,
+          // it should not be rendered twice.
+          if (this.enum[i] === enumDefaultValue) {
+            continue;
+          }
+
           this.dom.select.option = document.createElement('option');
           this.dom.select.option.value = this.enum[i];
           this.dom.select.option.innerHTML = this.enum[i];

--- a/test/test_schema.html
+++ b/test/test_schema.html
@@ -51,6 +51,9 @@
       "gender": {
         "enum": ["male", "female"]
       },
+      "academicDegree": {
+        "enum": [null, "B.S.", "M.S.", "Ph.D."] // enum with default blank value in list
+      },
       "age": {
         "description": "Age in years",
         "type": "integer",
@@ -77,13 +80,15 @@
       console.error(err);
     },
     schema: schema,
-    schemaRefs: {"hobbies.json": hobbiesSchema}
+    schemaRefs: {"hobbies.json": hobbiesSchema},
+    enumDefaultValue: null
   };
 
   var json = {
     "firstName": "Jos",
     "lastName": "de Jong",
-    gender: null,
+    "gender": null,
+    "academicDegree": null,
     "age": 34.2,
     "hobbies": [
         "programming",


### PR DESCRIPTION
Adds an option to configure blank value for enum lists in shema.
Adds support for enum lists containing the blank value. (Currently double blank options where rendered in list)

```
var container = document.getElementById('jsoneditor');

var schema = {
  "title": "Example Schema",
  "type": "object",
  "properties": {
    "academicDegree": {
      "enum": [null, "B.S.", "M.S.", "Ph.D."]
    }
  }
};

var options = {
  mode: 'tree',
  schema: schema,
  enumDefaultValue: null
};

var json = {
  "academicDegree": null
};

var editor = new JSONEditor(container, options, json);
```