### PR TITLE
Add ability to add to/customize context menu

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -146,11 +146,11 @@ Constructs a new JSONEditor.
   
   See also option `schema` for JSON schema validation.
   
-- `{function} onCreateMenu(items,path)`
+- `{function} onCreateMenu(items,{path})`
   
   Customize context menus in tree mode.
   
-  Sets a callback function to customize the context menu in tree mode. Each time the user clicks on the context menu button, an array of menu items is created. If this callback is set, the array is passed to this function along with the current path (if any). This function can customize any aspect of these menu items, including deleting them and/or adding new items. Each menu item is represented by an object, which may also contain a submenu array of items. See the source code of example 21 in the examples folder for more info on the format of the items and submenu objects.
+  Sets a callback function to customize the context menu in tree mode. Each time the user clicks on the context menu button, an array of menu items is created. If this callback is set, the array is passed to this function along with an object containing the current path (if any). This function can customize any aspect of these menu items, including deleting them and/or adding new items. Each menu item is represented by an object, which may also contain a submenu array of items. See the source code of example 21 in the examples folder for more info on the format of the items and submenu objects.
   
   The function should return the final array of menu items to be displayed to the user. 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,8 +143,17 @@ Constructs a new JSONEditor.
     }
   }
   ```
-
+  
   See also option `schema` for JSON schema validation.
+  
+- `{function} onCreateMenu(items,path)`
+  
+  Customize context menus in tree mode.
+  
+  Sets a callback function to customize the context menu in tree mode. Each time the user clicks on the context menu button, an array of menu items is created. If this callback is set, the array is passed to this function along with the current path (if any). This function can customize any aspect of these menu items, including deleting them and/or adding new items. Each menu item is represented by an object, which may also contain a submenu array of items. See the source code of example 21 in the examples folder for more info on the format of the items and submenu objects.
+  
+  The function should return the final array of menu items to be displayed to the user. 
+
 
 - `{boolean} escapeUnicode`
 

--- a/examples/21_customize_context_menu.html
+++ b/examples/21_customize_context_menu.html
@@ -1,0 +1,177 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>JSONEditor | Basic usage</title>
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+  #jsoneditor {
+    width: 500px;
+    height: 500px;
+  }
+
+  .submenu-highlight { background-color: yellow !important; }
+
+  .rainbow {
+
+    background: linear-gradient(to right, cyan, yellow, violet, green, orange, blue) !important;
+  }
+
+  .example-class > .jsoneditor-icon {
+
+    background-position: -168px -48px; /* warning triangle */
+
+  }
+
+  .dotty {
+    border-top : 1px dotted #e5e5e5 !important;
+  }
+
+  </style>
+</head>
+<body>
+  <h1>Context Menu Customization</h1>
+  <p>
+    This example demonstrates the use of the onCreateMenu callback option, which
+    allows you to customise context menus after they are created but before they
+    are shown to the user. You can alter/delete existing items as well as
+    adding new menu items. See the source code for this example for more
+    information.
+  </p>
+  <p>
+    <button id="setJSON">Set JSON</button>
+  </p>
+  <div id="jsoneditor"></div>
+
+  <script>
+  // create the editor
+  var container = document.getElementById('jsoneditor');
+
+  var options = {
+
+    // onCreateMenu allows us to register a call back function to customise
+    // the context menu. The callback accpets two parameters, items and path.
+    // Items is an array containing the current menu items, and path
+    // (if present) contains the path of the current node (as an array).
+    // The callback should return the modified (or unmodified) list of menu
+    // items.
+
+    // Every time the user clicks on a context menu button, the menu
+    // is created from scratch and this callback is called.
+
+    onCreateMenu : (items, path) => {
+
+      console.log(items); // log the current items for inspection
+
+      // We are going to add a menu item which returns the current node path
+      // as a jq path selector ( https://stedolan.github.io/jq/ ). First we
+      // will create a function, and then We will connect this function to
+      // the menu item click property in a moment.
+
+      function pathTojq() {
+
+        var pathString = '';
+
+        path.forEach(function (segment, index) { // path is an array, loop through it
+
+          if ( typeof segment == 'number') {  // format the selector for array indexs ...
+
+            pathString += `[${segment}]`;
+
+          } else {  // ... or object keys
+
+            pathString += `."${segment}"`;
+
+          }
+
+        })
+
+        alert(pathString); // show it to the user.
+
+      };
+
+      // Create a new menu item. For our example, we only want to do this
+      // if there is a path (in the case of appendnodes (for new objects)
+      // path is null until a node is created)
+
+      if (path) {
+
+        // Each item in the items array represents a menu item,
+        // and requires the following details :
+
+        items.push( {
+
+          text : 'jq Path', // the text for the menu item
+          title : 'Show the jq path for this node', // the HTML title attribute
+          className : 'example-class', // the css class name(s) for the menu item
+          click : pathTojq // the function to call when the menu item is clicked
+
+        } );
+
+      };
+
+      // Now we will iterate through the menu items, which includes the items
+      // created by jsoneditor, and the new item we added above. In this
+      // example we will just alter the className property for the items, but
+      // you can alter any property (e.g. the click callback, text property etc.)
+      // for any item, or even delete the whole menu item.
+
+      items.forEach( (item, index, items) => {
+
+        if ( "submenu" in item ) {
+
+          // if the item has a submenu property, it is a submenu heading
+          // and contains another array of menu items. Let's colour
+          // that yellow...
+
+          items[index].className += ' submenu-highlight';
+
+        } else {
+
+          // if it's not a submenu heading, let's make it colorful
+
+          items[index].className += ' rainbow';
+
+        }
+      })
+
+      // note that the above loop isn't recursive, so it only alters the classes
+      // on the top-level menu items. To also process menu items in submenus
+      // you should iterate through any "submenu" arrays of items if the item has one.
+
+      // next, just for fun, let's remove any menu separators (again just at the
+      // top level menu). A menu separator is an item with a type : 'separator'
+      // property
+
+      items = items.filter( (item) => { return ! (item.type == 'separator') })
+
+      // finally we need to return the items array. If we don't, the menu
+      // will be empty.
+
+      return items;
+
+    }
+  };
+
+  var editor = new JSONEditor(container, options);
+
+  // set json
+  document.getElementById('setJSON').onclick = function () {
+    var json = {
+      'array': [1, 2, 3],
+      'boolean': true,
+      'color': '#82b92c',
+      'null': null,
+      'number': 123,
+      'object': {'a': 'b', 'c': 'd'},
+      'string': 'Hello World'
+    };
+    editor.set(json);
+  };
+
+
+</script>
+</body>
+</html>

--- a/examples/21_customize_context_menu.html
+++ b/examples/21_customize_context_menu.html
@@ -61,7 +61,7 @@
     // Every time the user clicks on a context menu button, the menu
     // is created from scratch and this callback is called.
 
-    onCreateMenu : (items, path) => {
+    onCreateMenu : (items, {path}) => {
 
       console.log(items); // log the current items for inspection
 

--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -173,7 +173,7 @@ JSONEditor.VALID_OPTIONS = [
   'ajv', 'schema', 'schemaRefs','templates',
   'ace', 'theme', 'autocomplete',
   'onChange', 'onChangeJSON', 'onChangeText',
-  'onEditable', 'onError', 'onEvent', 'onModeChange', 'onNodeName', 'onValidate',
+  'onEditable', 'onError', 'onEvent', 'onModeChange', 'onNodeName', 'onValidate', 'onCreateMenu',
   'onSelectionChange', 'onTextSelectionChange', 'onClassName',
   'colorPicker', 'onColorPicker',
   'timestampTag',

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4373,7 +4373,7 @@ Node.prototype.showContextMenu = function (anchor, onClose) {
   }
 
   if (this.editor.options.onCreateMenu) {
-		items = this.editor.options.onCreateMenu(items, node.getPath());
+		items = this.editor.options.onCreateMenu(items, { path : node.getPath() });
 	}
   
   var menu = new ContextMenu(items, {close: onClose});

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4373,7 +4373,7 @@ Node.prototype.showContextMenu = function (anchor, onClose) {
   }
 
   if (this.editor.options.onCreateMenu) {
-			items = this.editor.options.onCreateMenu(items, node);
+		items = this.editor.options.onCreateMenu(items, node.getPath());
 	}
   
   var menu = new ContextMenu(items, {close: onClose});

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4372,6 +4372,10 @@ Node.prototype.showContextMenu = function (anchor, onClose) {
     }
   }
 
+  if (this.editor.options.onCreateMenu) {
+			items = this.editor.options.onCreateMenu(items, node);
+	}
+  
   var menu = new ContextMenu(items, {close: onClose});
   menu.show(anchor, this.editor.frame);
 };

--- a/src/js/appendNodeFactory.js
+++ b/src/js/appendNodeFactory.js
@@ -200,6 +200,10 @@ function appendNodeFactory(Node) {
         'submenu': appendSubmenu
       }
     ];
+    
+  if (this.editor.options.onCreateMenu) {
+		items = this.editor.options.onCreateMenu(items, node.getPath());
+	}
 
     var menu = new ContextMenu(items, {close: onClose});
     menu.show(anchor, this.editor.content);

--- a/src/js/appendNodeFactory.js
+++ b/src/js/appendNodeFactory.js
@@ -202,7 +202,7 @@ function appendNodeFactory(Node) {
     ];
     
   if (this.editor.options.onCreateMenu) {
-		items = this.editor.options.onCreateMenu(items, node.getPath());
+		items = this.editor.options.onCreateMenu(items, { path : node.getPath() });
 	}
 
     var menu = new ContextMenu(items, {close: onClose});

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -1693,6 +1693,10 @@ treemode.showContextMenu = function (anchor, onClose) {
       Node.onRemove(selectedNodes);
     }
   });
+  
+  if (this.editor.options.onCreateMenu) {
+		items = this.editor.options.onCreateMenu(items, node.getPath());
+	}
 
   var menu = new ContextMenu(items, {close: onClose});
   menu.show(anchor, this.frame);

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -1695,7 +1695,7 @@ treemode.showContextMenu = function (anchor, onClose) {
   });
   
   if (this.editor.options.onCreateMenu) {
-		items = this.editor.options.onCreateMenu(items, node.getPath());
+		items = this.editor.options.onCreateMenu(items, { path : node.getPath() });
 	}
 
   var menu = new ContextMenu(items, {close: onClose});


### PR DESCRIPTION
I see that the ability to add custom items to the context menu is in progress for version 6, however I'm guessing v6 is still some way away. 

This pull request introduces a simple way to allow customization of the context menu in the current version. It simply lets the user register an "onCreateMenu" function in options to which the contents of the menu "items" variable (plus reference to the current node) are passed before the menu is created from them.

I currently use it internally to add a custom menu item to display the current path as a JSON Pointer path (by pushing a new item onto items), and to alter the styling & text of some of the standard menu items depending on the current path (by altering existing item in items).

If this is something you want to incorporate, I can work up an example for the examples folder and additions to the api docs. 