### PR TITLE
Fixed using hyphens in the path of custom validation errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,8 +1706,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1728,14 +1727,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1750,20 +1747,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1880,8 +1874,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1893,7 +1886,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1908,7 +1900,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1916,14 +1907,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1942,7 +1931,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2023,8 +2011,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2036,7 +2023,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2122,8 +2108,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2159,7 +2144,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2179,7 +2163,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2223,14 +2206,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -787,7 +787,20 @@ exports.parsePath = function parsePath(jsonPath) {
 exports.stringifyPath = function stringifyPath(path) {
   return path
       .map(function (p) {
-        return typeof p === 'number' ? ('[' + p + ']') : p[0] === '[' ? p : ('.' + p);
+        if (typeof p === 'number'){
+          return ('[' + p + ']');
+        } else if(p[0] === '[') {
+          var end = p.indexOf(']');
+          if(end === -1) {
+            throw new SyntaxError('Character ] expected in path');
+          }
+          if (end === 1) {
+            throw new SyntaxError('String expected after [');
+          }
+          return p;
+        } else {
+          return '.' + p;
+        }
       })
       .join('');
 };

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -789,10 +789,10 @@ exports.stringifyPath = function stringifyPath(path) {
       .map(function (p) {
         if (typeof p === 'number'){
           return ('[' + p + ']');
-        } else if(typeof p === 'string' && p.indexOf('-') >= 0) {
-          return '["' + p + '"]';
-        } else {
+        } else if(typeof p === 'string' && p.match(/^[A-Za-z0-9_$]+$/)) {
           return '.' + p;
+        } else {
+          return '["' + p + '"]';
         }
       })
       .join('');

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -787,7 +787,7 @@ exports.parsePath = function parsePath(jsonPath) {
 exports.stringifyPath = function stringifyPath(path) {
   return path
       .map(function (p) {
-        return typeof p === 'number' ? ('[' + p + ']') : ('.' + p);
+        return typeof p === 'number' ? ('[' + p + ']') : p[0] === '[' ? p : ('.' + p);
       })
       .join('');
 };

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -789,15 +789,8 @@ exports.stringifyPath = function stringifyPath(path) {
       .map(function (p) {
         if (typeof p === 'number'){
           return ('[' + p + ']');
-        } else if(p[0] === '[') {
-          var end = p.indexOf(']');
-          if(end === -1) {
-            throw new SyntaxError('Character ] expected in path');
-          }
-          if (end === 1) {
-            throw new SyntaxError('String expected after [');
-          }
-          return p;
+        } else if(typeof p === 'string' && p.indexOf('-') >= 0) {
+          return '["' + p + '"]';
         } else {
           return '.' + p;
         }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -106,7 +106,9 @@ describe('util', function () {
       assert.deepEqual(util.stringifyPath(['foo', 'bar']), '.foo.bar');
       assert.deepEqual(util.stringifyPath(['foo', 2]), '.foo[2]');
       assert.deepEqual(util.stringifyPath(['foo', 2, 'bar']), '.foo[2].bar');
+      assert.deepEqual(util.stringifyPath(['foo', 2, 'bar_baz']), '.foo[2].bar_baz');
       assert.deepEqual(util.stringifyPath(['foo', 'prop-with-hyphens']), '.foo["prop-with-hyphens"]');
+      assert.deepEqual(util.stringifyPath(['foo', 'prop with spaces']), '.foo["prop with spaces"]');
     })
 
     it ('should parse a json path', function () {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -106,12 +106,7 @@ describe('util', function () {
       assert.deepEqual(util.stringifyPath(['foo', 'bar']), '.foo.bar');
       assert.deepEqual(util.stringifyPath(['foo', 2]), '.foo[2]');
       assert.deepEqual(util.stringifyPath(['foo', 2, 'bar']), '.foo[2].bar');
-      assert.deepEqual(util.stringifyPath(['foo', '[\"prop-with-hyphens\"]']), '.foo["prop-with-hyphens"]');
-    })
-
-    it('should throw exceptions in case of invalid path components', function () {
-      assert.throws(function () {util.stringifyPath(['['])}, /Error/);
-      assert.throws(function () {util.stringifyPath(['[]'])}, /Error/);
+      assert.deepEqual(util.stringifyPath(['foo', 'prop-with-hyphens']), '.foo["prop-with-hyphens"]');
     })
 
     it ('should parse a json path', function () {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -100,6 +100,20 @@ describe('util', function () {
 
   describe('jsonPath', function () {
 
+    it('should stringify an array of paths', function() {
+      assert.deepEqual(util.stringifyPath([]), '');
+      assert.deepEqual(util.stringifyPath(['foo']), '.foo');
+      assert.deepEqual(util.stringifyPath(['foo', 'bar']), '.foo.bar');
+      assert.deepEqual(util.stringifyPath(['foo', 2]), '.foo[2]');
+      assert.deepEqual(util.stringifyPath(['foo', 2, 'bar']), '.foo[2].bar');
+      assert.deepEqual(util.stringifyPath(['foo', '[\"prop-with-hyphens\"]']), '.foo["prop-with-hyphens"]');
+    })
+
+    it('should throw exceptions in case of invalid path components', function () {
+      assert.throws(function () {util.stringifyPath(['['])}, /Error/);
+      assert.throws(function () {util.stringifyPath(['[]'])}, /Error/);
+    })
+
     it ('should parse a json path', function () {
       assert.deepEqual(util.parsePath(''), []);
       assert.deepEqual(util.parsePath('.foo'), ['foo']);


### PR DESCRIPTION
Using hyphens in the path of custom validation errors didn't work since the method `stringifyPath` previously added a dot to the start of anything which wasn't a number. This for example turned `fill-color` to `.fill-color` which is not a valid json path. Using bracket notation did not work either as `['fill-color']` was transformed to `.['fill-color']`. With this fix, using bracket notation works.