### PR TITLE
fix: when duplicate keys occur discard get function

### DIFF
--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -291,6 +291,14 @@ treemode.get = function () {
     }
   }
 
+  // discard when duplicate keys
+  if (this.node) {
+    var duplicateErrors = this.node.validate();
+    if (duplicateErrors && duplicateErrors.length > 0) {
+      throw duplicateErrors[0];
+    }
+  }
+
   if (this.node) {
     return this.node.getValue();
   }


### PR DESCRIPTION
when duplicate keys occur, onChangeJSON get a wrong json. when using in react and mobx, this bug will cause new key-value cover the original key-value
![bug-json](https://user-images.githubusercontent.com/14990734/54196550-b1fb6200-44fc-11e9-9c2e-a93cfac2c9ea.gif)

