### PR TITLE
fix：Modify the file address reference method

### DIFF
--- a/src/scss/statusbar.scss
+++ b/src/scss/statusbar.scss
@@ -22,7 +22,7 @@
 		height: 24px;
 		padding: 0;
 		margin-top: 1px;
-		background: url("img/jsoneditor-icons.svg") -168px -48px;
+		background: url("./img/jsoneditor-icons.svg") -168px -48px;
 		cursor: pointer;
 	}
 	& > .jsoneditor-validation-error-count {
@@ -36,7 +36,7 @@
 		height: 24px;
 		padding: 0;
 		margin: 1px;
-		background: url("img/jsoneditor-icons.svg") -25px 0px;
+		background: url("./img/jsoneditor-icons.svg") -25px 0px;
 	}
 	.jsoneditor-array-info {
 		a {


### PR DESCRIPTION
I think this should be consistent with the other file references (searchbox.scss, jsoneditor.scss), otherwise the jsoneditor-icons.svg file will not be found after the file-loader processing in webpack.