### PR TITLE
change jsoneditor dependency property value.

### DIFF
--- a/examples/react_advanced_demo/package.json
+++ b/examples/react_advanced_demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "jsoneditor": "file:../..",
+    "jsoneditor": "^7.0.3",
     "lodash": "4.17.15",
     "react": "16.9.0",
     "react-dom": "16.9.0",

--- a/examples/react_demo/package.json
+++ b/examples/react_demo/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "jsoneditor": "file:../..",
+    "jsoneditor": "^7.0.3",
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-scripts": "3.1.1"


### PR DESCRIPTION
Adding the jsoneditor version into package.json `npm install` did not install jsoneditor with "file:../..".

When I ran `npm start` after install it threw me a failed to compile error since it did not install jsoneditor. 
![image](https://user-images.githubusercontent.com/13111030/64442962-7d084a80-d0ee-11e9-8114-cb2d33371347.png)
