### PR TITLE
Set color for text in search box

### DIFF
--- a/src/scss/searchbox.scss
+++ b/src/scss/searchbox.scss
@@ -10,6 +10,7 @@
     display: flex;
 
     input {
+      color: $jse-content-color;
       width: 120px;
       border: none;
       outline: none;


### PR DESCRIPTION
Since version 7 of jsoneditor color of text in search box became white in my project. White text on white background is invisible. Problem is related with bootstrap 3 which I also use in project, it adds such CSS rule:
```less
input {
  color: inherit;
}
```
for jsoneditor it means that `.jsoneditor-search input` will inherit white text color from `.jsoneditor-menu`.
I'm not sure whether this issue should be fixed in jsoneditor or I just should set color in my project.