### PR TITLE
fix the z-index for context button in tree mode

### DIFF
--- a/src/scss/jsoneditor.scss
+++ b/src/scss/jsoneditor.scss
@@ -144,6 +144,7 @@ div {
         margin: 0;
         border: none;
         cursor: pointer;
+        z-index: auto;
         background: transparent url("./img/jsoneditor-icons.svg");
         &:focus {
           background-color: $jse-preview;


### PR DESCRIPTION
Try to fix the following problem related to CSS `z-index`

![Screenshot_20191024_152333](https://user-images.githubusercontent.com/3369760/67464236-969d2b80-f675-11e9-8855-f73d14fe031c.png)

![Screenshot_20191024_152413](https://user-images.githubusercontent.com/3369760/67464237-9735c200-f675-11e9-83af-c23476793c24.png)
