### PR TITLE
docs: Fix simple typo, vaidation -> validation

### DIFF
--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -171,7 +171,7 @@ function JSONEditor (container, options, json) {
  */
 JSONEditor.modes = {}
 
-// debounce interval for JSON schema vaidation in milliseconds
+// debounce interval for JSON schema validation in milliseconds
 JSONEditor.prototype.DEBOUNCE_INTERVAL = 150
 
 JSONEditor.VALID_OPTIONS = [


### PR DESCRIPTION
There is a small typo in src/js/JSONEditor.js.

Should read `validation` rather than `vaidation`.

