### PR TITLE
Multi-select mouse events now honor the event's window

### DIFF
--- a/examples/01_basic_usage.html
+++ b/examples/01_basic_usage.html
@@ -36,7 +36,8 @@
       'number': 123,
       'object': {'a': 'b', 'c': 'd'},
       'time': 1575599819000,
-      'string': 'Hello World'
+      'string': 'Hello World',
+      'onlineDemo': 'https://jsoneditoronline.org/'
     }
     editor.set(json)
   }

--- a/examples/24_new_window.html
+++ b/examples/24_new_window.html
@@ -30,12 +30,16 @@
       editor = undefined
     }
 
+    // make the necessary styles available within the child window
+    // for JSONEditor
     const baseUrl = window.location.href.slice(0, window.location.href.lastIndexOf('/'))
-
     const link = child.document.createElement("link")
     link.setAttribute("href", baseUrl + "/../dist/jsoneditor.css")
     link.setAttribute("rel", "stylesheet")
     child.document.head.append(link)
+    // for vanilla-picker
+    const colorPickerStyles = JSONEditor.VanillaPicker.StyleElement.cloneNode(true)
+    child.document.head.append(colorPickerStyles)
 
     const container = child.document.createElement("div")
     child.document.body.append(container)

--- a/examples/24_new_window.html
+++ b/examples/24_new_window.html
@@ -33,10 +33,10 @@
     // make the necessary styles available within the child window
     // for JSONEditor
     const baseUrl = window.location.href.slice(0, window.location.href.lastIndexOf('/'))
-    const link = child.document.createElement("link")
-    link.setAttribute("href", baseUrl + "/../dist/jsoneditor.css")
-    link.setAttribute("rel", "stylesheet")
-    child.document.head.append(link)
+    const jsonEditorStyles = child.document.createElement("link")
+    jsonEditorStyles.setAttribute("href", baseUrl + "/../dist/jsoneditor.css")
+    jsonEditorStyles.setAttribute("rel", "stylesheet")
+    child.document.head.append(jsonEditorStyles)
     // for vanilla-picker
     const colorPickerStyles = JSONEditor.VanillaPicker.StyleElement.cloneNode(true)
     child.document.head.append(colorPickerStyles)
@@ -45,7 +45,10 @@
     child.document.body.append(container)
 
     // create the editor
-    const options = {}
+    const options = {
+      // Show sort and transform modals in the child window, not the parent.
+      modalAnchor: child.document.body
+    }
     editor = new JSONEditor(container, options)
   }
 

--- a/examples/24_new_window.html
+++ b/examples/24_new_window.html
@@ -1,0 +1,80 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <title>JSONEditor | New window</title>
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    #jsoneditor {
+      width: 500px;
+      height: 500px;
+    }
+  </style>
+</head>
+<body>
+<p>
+  <button id="openNewEditor">Open Editor in New Window</button>
+  <button id="setJSON">Set JSON</button>
+  <button id="getJSON">Get JSON</button>
+</p>
+
+<script>
+  let editor
+
+  function openNewEditor() {
+    const child = window.open("", "_blank", "width=400,height=400")
+    child.document.title = 'JSONEditor | New window'
+    child.onunload = function () {
+      editor = undefined
+    }
+
+    const baseUrl = window.location.href.slice(0, window.location.href.lastIndexOf('/'))
+
+    const link = child.document.createElement("link")
+    link.setAttribute("href", baseUrl + "/../dist/jsoneditor.css")
+    link.setAttribute("rel", "stylesheet")
+    child.document.head.append(link)
+
+    const container = child.document.createElement("div")
+    child.document.body.append(container)
+
+    // create the editor
+    const options = {}
+    editor = new JSONEditor(container, options)
+  }
+
+  // create a new window
+  document.getElementById('openNewEditor').onclick = openNewEditor
+
+  // set json
+  document.getElementById('setJSON').onclick = function () {
+    if (!editor) {
+      openNewEditor()
+    }
+    const json = {
+      'array': [1, 2, 3],
+      'boolean': true,
+      'color': '#82b92c',
+      'null': null,
+      'number': 123,
+      'object': {'a': 'b', 'c': 'd'},
+      'time': 1575599819000,
+      'string': 'Hello World'
+    }
+    editor.set(json)
+  }
+
+  // get json
+  document.getElementById('getJSON').onclick = function () {
+    if (!editor) {
+      alert('No editor is open')
+    } else {
+      const json = editor.get()
+      alert(JSON.stringify(json, null, 2))
+    }
+  }
+</script>
+</body>
+</html>

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -3917,7 +3917,7 @@ export class Node {
     const json = this.getValue()
 
     showTransformModal({
-      anchor: modalAnchor || DEFAULT_MODAL_ANCHOR,
+      container: modalAnchor || DEFAULT_MODAL_ANCHOR,
       json,
       queryDescription, // can be undefined
       createQuery,

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -2574,7 +2574,7 @@ export class Node {
             // if read-only, we use the regular click behavior of an anchor
             if (isUrl(this.value)) {
               event.preventDefault()
-              window.open(this.value, '_blank')
+              window.open(this.value, '_blank', 'noopener')
             }
           }
           break
@@ -2729,7 +2729,7 @@ export class Node {
       if (target === this.dom.value) {
         if (!this.editable.value || event.ctrlKey) {
           if (isUrl(this.value)) {
-            window.open(this.value, '_blank')
+            window.open(this.value, '_blank', 'noopener')
             handled = true
           }
         }

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4116,13 +4116,13 @@ Node.onDragStart = (nodes, event) => {
   const offsetY = getAbsoluteTop(draggedNode.dom.tr) - getAbsoluteTop(firstNode.dom.tr)
 
   if (!editor.mousemove) {
-    editor.mousemove = addEventListener(window, 'mousemove', event => {
+    editor.mousemove = addEventListener(event.view, 'mousemove', event => {
       Node.onDrag(nodes, event)
     })
   }
 
   if (!editor.mouseup) {
-    editor.mouseup = addEventListener(window, 'mouseup', event => {
+    editor.mouseup = addEventListener(event.view, 'mouseup', event => {
       Node.onDragEnd(nodes, event)
     })
   }
@@ -4378,11 +4378,11 @@ Node.onDragEnd = (nodes, event) => {
   delete editor.drag
 
   if (editor.mousemove) {
-    removeEventListener(window, 'mousemove', editor.mousemove)
+    removeEventListener(event.view, 'mousemove', editor.mousemove)
     delete editor.mousemove
   }
   if (editor.mouseup) {
-    removeEventListener(window, 'mouseup', editor.mouseup)
+    removeEventListener(event.view, 'mouseup', editor.mouseup)
     delete editor.mouseup
   }
 

--- a/src/js/previewmode.js
+++ b/src/js/previewmode.js
@@ -398,7 +398,7 @@ previewmode._showTransformModal = function () {
     this._renderPreview() // update array count
 
     showTransformModal({
-      anchor: modalAnchor || DEFAULT_MODAL_ANCHOR,
+      container: modalAnchor || DEFAULT_MODAL_ANCHOR,
       json,
       queryDescription, // can be undefined
       createQuery,

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -476,7 +476,7 @@ textmode._showTransformModal = function () {
   const json = this.get()
 
   showTransformModal({
-    anchor: modalAnchor || DEFAULT_MODAL_ANCHOR,
+    container: modalAnchor || DEFAULT_MODAL_ANCHOR,
     json,
     queryDescription, // can be undefined
     createQuery,

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -244,7 +244,7 @@ textmode.create = function (container, options = {}) {
         // TODO: this anchor falls below the margin of the content,
         // therefore the normal a.href does not work. We use a click event
         // for now, but this should be fixed.
-        window.open(poweredBy.href, poweredBy.target)
+        window.open(poweredBy.href, poweredBy.target, 'noopener')
       }
       this.menu.appendChild(poweredBy)
     }

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -25,7 +25,8 @@ import {
   repair,
   selectContentEditable,
   setSelectionOffset,
-  isValidationErrorChanged
+  isValidationErrorChanged,
+  getWindow
 } from './util'
 import { autocomplete } from './autocomplete'
 import { setLanguage, setLanguages, translate } from './i18n'
@@ -136,7 +137,7 @@ treemode._setOptions = function (options) {
         // when there is not enough space below, and there is enough space above
         const pickerHeight = 300 // estimated height of the color picker
         const top = parent.getBoundingClientRect().top
-        const windowHeight = window.innerHeight
+        const windowHeight = getWindow(parent).innerHeight
         const showOnTop = ((windowHeight - top) < pickerHeight && top > pickerHeight)
 
         new VanillaPicker({

--- a/src/js/treemode.js
+++ b/src/js/treemode.js
@@ -1280,7 +1280,7 @@ treemode._updateDragDistance = function (event) {
 
 /**
  * Start multi selection of nodes by dragging the mouse
- * @param event
+ * @param {MouseEvent} event
  * @private
  */
 treemode._onMultiSelectStart = function (event) {
@@ -1302,12 +1302,12 @@ treemode._onMultiSelectStart = function (event) {
 
   const editor = this
   if (!this.mousemove) {
-    this.mousemove = addEventListener(window, 'mousemove', event => {
+    this.mousemove = addEventListener(event.view, 'mousemove', event => {
       editor._onMultiSelect(event)
     })
   }
   if (!this.mouseup) {
-    this.mouseup = addEventListener(window, 'mouseup', event => {
+    this.mouseup = addEventListener(event.view, 'mouseup', event => {
       editor._onMultiSelectEnd(event)
     })
   }
@@ -1317,7 +1317,7 @@ treemode._onMultiSelectStart = function (event) {
 
 /**
  * Multiselect nodes by dragging
- * @param event
+ * @param {MouseEvent} event
  * @private
  */
 treemode._onMultiSelect = function (event) {
@@ -1360,9 +1360,10 @@ treemode._onMultiSelect = function (event) {
 
 /**
  * End of multiselect nodes by dragging
+ * @param {MouseEvent} event
  * @private
  */
-treemode._onMultiSelectEnd = function () {
+treemode._onMultiSelectEnd = function (event) {
   // set focus to the context menu button of the first node
   if (this.multiselection.nodes[0]) {
     this.multiselection.nodes[0].dom.menu.focus()
@@ -1373,11 +1374,11 @@ treemode._onMultiSelectEnd = function () {
 
   // cleanup global event listeners
   if (this.mousemove) {
-    removeEventListener(window, 'mousemove', this.mousemove)
+    removeEventListener(event.view, 'mousemove', this.mousemove)
     delete this.mousemove
   }
   if (this.mouseup) {
-    removeEventListener(window, 'mouseup', this.mouseup)
+    removeEventListener(event.view, 'mouseup', this.mouseup)
     delete this.mouseup
   }
 }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -456,6 +456,16 @@ export function isArray (obj) {
 }
 
 /**
+ * Gets a DOM element's Window.  This is normally just the global `window`
+ * variable, but if we opened a child window, it may be different.
+ * @param {HTMLElement} element
+ * @return {Window}
+ */
+export function getWindow (element) {
+  return element.ownerDocument.defaultView;
+}
+
+/**
  * Retrieve the absolute left value of a DOM element
  * @param {Element} elem    A dom element, for example a div
  * @return {Number} left    The absolute left position of this element

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -789,7 +789,7 @@ export function isFirefox () {
 var _ieVersion = -1
 
 /**
- * Add and event listener. Works for all browsers
+ * Add an event listener. Works for all browsers
  * @param {Element}     element    An html element
  * @param {string}      action     The action, for example "click",
  *                                 without the prefix "on"
@@ -1139,7 +1139,7 @@ export function getInputSelection (el) {
 }
 
 /**
- * Returns the index for certaion position in text element
+ * Returns the index for certain position in text element
  * @param {DOMElement} el A dom element of a textarea or input text.
  * @param {Number} row row value, > 0, if exceeds rows number - last row will be returned
  * @param {Number} column column value, > 0, if exceeds column length - end of column will be returned
@@ -1499,7 +1499,7 @@ export function contains (array, item) {
 }
 
 /**
- * Checkes if validation has changed from the previous execution
+ * Checks if validation has changed from the previous execution
  * @param {Array} currErr current validation errors
  * @param {Array} prevErr previous validation errors
  */


### PR DESCRIPTION
My app uses [window.open](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) via [react-new-window](https://github.com/rmariuzzo/react-new-window) to show a JSONEditor instance in a separate browser window. When I interact with the editor and then close the separate window, I start getting JavaScript errors when I moved the mouse over the main window:

```
Uncaught TypeError: Cannot read property 'nodes' of null
    at v.H._onMultiSelectEnd (0:50503)
    at 0:50440
```

It appears that the problem is caused by JSONEditor's use of the `window` global variable - that causes any event handling to be done in the main window, so the child window doesn't get events and can't properly clean up. From reading MDN and doing some local testing, using [event.view](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/view) instead seems to be the best fix.

I saw that the JSONEditor source code contains other references to the `window` global. I haven't seen problems from them yet, but I'm only using part of JSONEditor's functionality, and they may need to be fixed eventually to fully support use from `window.open`. (Using [Node.ownerDocument](https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument) and [Document.defaultView](https://developer.mozilla.org/en-US/docs/Web/API/Document/defaultView) from the editor's DOM node looks like it should work, although I haven't tested it.)

All of this seems like an unusual use case, so let me know if it's out of scope for JSONEditor, if you'd like a different approach, and/or if you'd like me to look into the other `window` uses.

Thank you.