### PR TITLE
Update react advanced example

### DIFF
--- a/examples/react_advanced_demo/src/JSONEditorReact.js
+++ b/examples/react_advanced_demo/src/JSONEditorReact.js
@@ -21,7 +21,7 @@ export default class JSONEditorReact extends Component {
       this.jsoneditor.set(this.props.json);
     }
   
-    if ((this.jsoneditor.getText() == "{}") && ('text' in this.props)) {
+    if ('text' in this.props) {
       this.jsoneditor.setText(this.props.text);
     }
     this.schema = cloneDeep(this.props.schema);
@@ -33,7 +33,7 @@ export default class JSONEditorReact extends Component {
       this.jsoneditor.update(this.props.json);
     }
 
-    if ('text' in this.props) {
+    if ((this.jsoneditor.getText() == "{}") && ('text' in this.props)) {
       this.jsoneditor.updateText(this.props.text);
     }
 

--- a/examples/react_advanced_demo/src/JSONEditorReact.js
+++ b/examples/react_advanced_demo/src/JSONEditorReact.js
@@ -20,7 +20,8 @@ export default class JSONEditorReact extends Component {
     if ('json' in this.props) {
       this.jsoneditor.set(this.props.json);
     }
-    if ('text' in this.props) {
+  
+    if ((this.jsoneditor.getText() == "{}") && ('text' in this.props)) {
       this.jsoneditor.setText(this.props.text);
     }
     this.schema = cloneDeep(this.props.schema);


### PR DESCRIPTION
We should update text only once on the first render.
In other cases, the cursor will go to the beginning every time we pressing `Enter`.