### PR TITLE
Fix for issue #1111

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4448,7 +4448,7 @@ Node._findSchema = (schema, schemaRefs, path) => {
 
       if (typeof key === 'string' && childSchema.patternProperties && !(childSchema.properties && key in childSchema.properties)) {
         for (const prop in childSchema.patternProperties) {
-          if (key.match(prop)) {
+          if (key.match(prop) && (foundSchema.properties || foundSchema.patternProperties)) {
             foundSchema = Node._findSchema(childSchema.patternProperties[prop], schemaRefs, nextPath)
           }
         }


### PR DESCRIPTION
Fixes enum dropdown not showing when using patternProperties for schema.

The issue happens as `_findSchema` is recursively called one more than than it should. Instead of returning the nested schema object (eg. `{ enum: [1, 2, 3] }`), it returns the parent object, eg.:

```javascript
{
  type: 'object',
  properties: {
    testrigId: {
      enum: [1, 2, 3]
    },
  },
  required: [
    'testrigId'
  ]
}
```

The fix adds a check to only call the `_findSchema` again if the object contains properties. 

The unit tests pass and I've also tested a complex schema inside `patternProperties` that uses the special types (boolean, color, enum).