### PR TITLE
Fix schema not found if using internal references

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4451,56 +4451,54 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
   const nextPath = path.slice(1, path.length)
   const nextKey = path[0]
 
-  let possibleSchemas = currentSchema.oneOf || currentSchema.anyOf || currentSchema.allOf || [currentSchema];
+  const possibleSchemas = currentSchema.oneOf || currentSchema.anyOf || currentSchema.allOf || [currentSchema]
 
-  for (let schema of possibleSchemas) {
-    currentSchema = schema;
+  for (const schema of possibleSchemas) {
+    currentSchema = schema
 
     if ('$ref' in currentSchema && typeof currentSchema.$ref === 'string') {
-      let ref = currentSchema.$ref;
-      if(ref in schemaRefs) {
-        currentSchema = schemaRefs[ref];
-      }
-      else if (ref.startsWith("#/")) {
-        let refPath = ref.substring(2).split("/");
-        currentSchema = topLevelSchema;
-        for (let segment of refPath) {
+      const ref = currentSchema.$ref
+      if (ref in schemaRefs) {
+        currentSchema = schemaRefs[ref]
+      } else if (ref.startsWith('#/')) {
+        const refPath = ref.substring(2).split('/')
+        currentSchema = topLevelSchema
+        for (const segment of refPath) {
           if (segment in currentSchema) {
-            currentSchema = currentSchema[segment];
+            currentSchema = currentSchema[segment]
           } else {
-            throw Error(`Unable to resovle reference ${ref}`);
+            throw Error(`Unable to resovle reference ${ref}`)
           }
         }
-      }
-      else {
-        throw Error(`Unable to resolve reference ${ref}`);
+      } else {
+        throw Error(`Unable to resolve reference ${ref}`)
       }
     }
 
     // We have no more path segments to resolve, return the currently found schema
     // We do this here, after resolving references, in case of the leaf schema beeing a reference
     if (nextKey === undefined) {
-      return currentSchema;
+      return currentSchema
     }
 
     if (typeof nextKey === 'string') {
       if (typeof currentSchema.properties === 'object' && currentSchema.properties !== null && nextKey in currentSchema.properties) {
-        currentSchema = currentSchema.properties[nextKey];
+        currentSchema = currentSchema.properties[nextKey]
         return Node._findSchema(topLevelSchema, schemaRefs, nextPath, currentSchema)
-      } 
+      }
       if (typeof currentSchema.patternProperties === 'object' && currentSchema.patternProperties !== null) {
         for (const prop in currentSchema.patternProperties) {
           if (nextKey.match(prop)) {
             currentSchema = currentSchema.patternProperties[prop]
-            return Node._findSchema(topLevelSchema, schemaRefs, nextPath, currentSchema);
+            return Node._findSchema(topLevelSchema, schemaRefs, nextPath, currentSchema)
           }
         }
       }
-      continue;
+      continue
     }
-     if (typeof nextKey === 'number' && typeof currentSchema.items === 'object' && currentSchema.items !== null) {
+    if (typeof nextKey === 'number' && typeof currentSchema.items === 'object' && currentSchema.items !== null) {
       currentSchema = currentSchema.items
-      return Node._findSchema(topLevelSchema, schemaRefs, nextPath, currentSchema);
+      return Node._findSchema(topLevelSchema, schemaRefs, nextPath, currentSchema)
     }
   }
 

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -119,41 +119,41 @@ describe('Node', () => {
     describe('with $ref to internal definition', () => {
       it('should find a referenced schema', () => {
         const schema = {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "type": "object",
-          "patternProperties": {
-              "^/[a-z0-9]*$": {
-                  "$ref": "#/definitions/component"
-              }
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          patternProperties: {
+            '^/[a-z0-9]*$': {
+              $ref: '#/definitions/component'
+            }
           },
-          "definitions": {
-                  "component": {
-                      "type": "object",
-                      "properties": {
-                          "type": {
-                              "type": "string",
-                              "minLength": 1
-                          },
-                          "config": {
-                              "type": "object"
-                          },
-                          "children": {
-                              "type": "object",
-                              "patternProperties": {
-                                  "^/[a-z0-9]+$": {
-                                      "$ref": "#/definitions/component"
-                                  }
-                              }
-                          }
-                      }
+          definitions: {
+            component: {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  minLength: 1
+                },
+                config: {
+                  type: 'object'
+                },
+                children: {
+                  type: 'object',
+                  patternProperties: {
+                    '^/[a-z0-9]+$': {
+                      $ref: '#/definitions/component'
+                    }
                   }
+                }
+              }
+            }
           }
-        };
-        const path = ["/status", "children", "/bus", "config"];
+        }
+        const path = ['/status', 'children', '/bus', 'config']
         const foundSchema = {
-          type: "object"
-        };
-        assert.notStrictEqual(Node._findSchema(schema, {}, path), foundSchema);
+          type: 'object'
+        }
+        assert.notStrictEqual(Node._findSchema(schema, {}, path), foundSchema)
       })
     })
 

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -116,6 +116,47 @@ describe('Node', () => {
       })
     })
 
+    describe('with $ref to internal definition', () => {
+      it('should find a referenced schema', () => {
+        const schema = {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "patternProperties": {
+              "^/[a-z0-9]*$": {
+                  "$ref": "#/definitions/component"
+              }
+          },
+          "definitions": {
+                  "component": {
+                      "type": "object",
+                      "properties": {
+                          "type": {
+                              "type": "string",
+                              "minLength": 1
+                          },
+                          "config": {
+                              "type": "object"
+                          },
+                          "children": {
+                              "type": "object",
+                              "patternProperties": {
+                                  "^/[a-z0-9]+$": {
+                                      "$ref": "#/definitions/component"
+                                  }
+                              }
+                          }
+                      }
+                  }
+          }
+        };
+        const path = ["/status", "children", "/bus", "config"];
+        const foundSchema = {
+          type: "object"
+        };
+        assert.notStrictEqual(Node._findSchema(schema, {}, path), foundSchema);
+      })
+    })
+
     describe('with pattern properties', () => {
       it('should find schema', () => {
         const schema = {


### PR DESCRIPTION
This merge request fixes issue #1158 
I refactored the `Node._findSchema` method, which now should correctly resolve internal references. I also added a test case for this.