### PR TITLE
Resolve additionalProperties schema

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4496,6 +4496,10 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
           }
         }
       }
+      if (typeof currentSchema.additionalProperties === 'object') {
+        currentSchema = currentSchema.additionalProperties
+        return Node._findSchema(topLevelSchema, schemaRefs, nextPath, currentSchema)
+      }
       continue
     }
     if (typeof nextKey === 'number' && typeof currentSchema.items === 'object' && currentSchema.items !== null) {

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -329,6 +329,12 @@ describe('Node', () => {
             company: {
               type: "string",
               enum: ["1", "2"]
+            },
+            nested: {
+              type: 'object',
+              additionalProperties: {
+                type: "number"
+              }
             }
           },
           additionalProperties: {
@@ -340,6 +346,12 @@ describe('Node', () => {
         assert.strictEqual(
           Node._findSchema(schema, {}, path),
           schema.additionalProperties,
+          'additionalProperties schema'
+        )
+        path = ['nested', 'virtual']
+        assert.strictEqual(
+          Node._findSchema(schema, {}, path),
+          schema.properties.nested.additionalProperties,
           'additionalProperties schema'
         )
       })

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -321,6 +321,28 @@ describe('Node', () => {
         path = ['levelOne', 'not-in-schema']
         assert.strictEqual(Node._findSchema(schema, {}, path), null)
       })
+
+      it('should return additionalProperties schema', () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            company: {
+              type: "string",
+              enum: ["1", "2"]
+            }
+          },
+          additionalProperties: {
+              type: "string",
+              enum: ["1", "2"]
+          }
+        };
+        let path = ['company2']
+        assert.strictEqual(
+          Node._findSchema(schema, {}, path),
+          schema.additionalProperties,
+          'additionalProperties schema'
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
This merge request improves the `Node._findSchema` function. It now returns schemas defined by the `additionalProperties` key. This might solve issue #1192 .