### PR TITLE
Fixes #1224 IgnorePlugin Issue in WebPack 5.11.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,10 +88,10 @@ const compilerMinimalist = webpack({
   module: webpackConfigModule,
   plugins: [
     bannerPlugin,
-    new webpack.IgnorePlugin(/^ace-builds/),
-    new webpack.IgnorePlugin(/worker-json-data-url/),
-    new webpack.IgnorePlugin(/^ajv/),
-    new webpack.IgnorePlugin(/^vanilla-picker/)
+    new webpack.IgnorePlugin({ resourceRegExp: /^ace-builds/ }),
+    new webpack.IgnorePlugin({ resourceRegExp: /worker-json-data-url/ }),
+    new webpack.IgnorePlugin({ resourceRegExp: /^ajv/ }),
+    new webpack.IgnorePlugin({ resourceRegExp: /^vanilla-picker/ })
   ],
   optimization: {
     // We no not want to minimize our code.


### PR DESCRIPTION
Fixed WebPack Ignore change in gulpjs file.

from WebPack 5 onwards:

"If you are using IgnorePlugin with a regular expression as argument, it takes an options object now: new IgnorePlugin({ resourceRegExp: /regExp/ }) "

https://webpack.js.org/migrate/5/