### PR TITLE
Added support for references to another scheme

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4472,6 +4472,15 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
             throw Error(`Unable to resovle reference ${ref}`)
           }
         }
+      } else if (ref.match('/#\//g').length === 1){
+        const [schemaUrl, relativePath] = ref.split('#/');
+        if( schemaUrl in schemaRefs){
+          const referencedSchema = schemaRefs[schemaUrl]
+          const reference = {$ref:'#/'.concat(relativePath)}
+          return Node._findSchema(referencedSchema, schemaRefs, [], reference)
+        } else {
+          throw Error(`Unable to resolve reference ${ref}`)
+        }
       } else {
         throw Error(`Unable to resolve reference ${ref}`)
       }

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4472,11 +4472,11 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
             throw Error(`Unable to resovle reference ${ref}`)
           }
         }
-      } else if (ref.match('/#\//g').length === 1){
-        const [schemaUrl, relativePath] = ref.split('#/');
-        if( schemaUrl in schemaRefs){
+      } else if (ref.match('/#//g').length === 1) {
+        const [schemaUrl, relativePath] = ref.split('#/')
+        if (schemaUrl in schemaRefs) {
           const referencedSchema = schemaRefs[schemaUrl]
-          const reference = {$ref:'#/'.concat(relativePath)}
+          const reference = { $ref: '#/'.concat(relativePath) }
           return Node._findSchema(referencedSchema, schemaRefs, [], reference)
         } else {
           throw Error(`Unable to resolve reference ${ref}`)

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4472,12 +4472,12 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
             throw Error(`Unable to resovle reference ${ref}`)
           }
         }
-      } else if (ref.match('/#//g').length === 1) {
+      } else if (ref.match(/#\//g)?.length === 1) {
         const [schemaUrl, relativePath] = ref.split('#/')
         if (schemaUrl in schemaRefs) {
           const referencedSchema = schemaRefs[schemaUrl]
           const reference = { $ref: '#/'.concat(relativePath) }
-          return Node._findSchema(referencedSchema, schemaRefs, [], reference)
+          return Node._findSchema(referencedSchema, schemaRefs, nextPath, reference)
         } else {
           throw Error(`Unable to resolve reference ${ref}`)
         }

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -157,6 +157,34 @@ describe('Node', () => {
       })
     })
 
+    describe('with $ref to external definition', () => {
+      it('should find a referenced schema', () => {
+        const schema = {
+          type: 'object',
+          properties: {
+            address: {
+              $ref: 'definitions.json#/address'
+            }
+          }
+        }
+        const definitions = {
+          address: {
+            type: 'object',
+            properties: {
+              country: {
+                type: 'string'
+              },
+              city: {
+                type: 'string'
+              }
+            }
+          }
+        }
+        const path = ['address', 'city']
+        const foundSchema = { type: 'string' }
+        assert.notStrictEqual(Node._findSchema(schema, { 'definitions.json': definitions }, path), foundSchema)
+      })
+    })
     describe('with pattern properties', () => {
       it('should find schema', () => {
         const schema = {


### PR DESCRIPTION
According to Json-schema documentation: 

> $ref can resolve to a URI that references another file, so if you prefer to include your definitions in separate files, you can also do that.

Extended _findSchema function's logic to work in such case.