### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:current-alpine AS builder
+WORKDIR /opt
+COPY package*.json /opt/
+RUN apk add python make g++ && \
+    npm install
+COPY . /opt/
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /opt/misc/index.html /opt/dist/jsoneditor.min.js /opt/dist/jsoneditor.min.css /opt/dist/img/jsoneditor-icons.svg /usr/share/nginx/html/
+EXPOSE 80

--- a/misc/index.html
+++ b/misc/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>JSONEditor</title>
+    <link href="jsoneditor.min.css" rel="stylesheet" type="text/css" />
+    <script src="jsoneditor.min.js"></script>
+  </head>
+  <body>
+    <div id="jsoneditor" style="width: 400px; height: 400px"></div>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <script>
+      // create the editor
+      const container = document.getElementById("jsoneditor");
+      const options = {};
+      const editor = new JSONEditor(container, options);
+
+      // set json
+      const initialJson = {
+        Array: [1, 2, 3],
+        Boolean: true,
+        Null: null,
+        Number: 123,
+        Object: { a: "b", c: "d" },
+        String: "Hello World",
+      };
+      editor.set(initialJson);
+
+      // get json
+      const updatedJson = editor.get();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Hi @josdejong 

I like JSONEditor, and since I like self hosting my tools too, here's a Dockerfile I made. It works like this

```bash
docker build -t local/jsoneditor:test .
docker run --name test -p80:80 -d local/jsoneditor:test
# open localhost:80 in your browser
docker rm -f test
```

I guess this could be added somewhere in the documentation.

The `misc/index.html` is a c/c of the README's example with a <title>. The result is bad, I hope you can provide a better one, a bit like the official jsoneditor website ?

Last but not least, I can provide a github action to build & push this into docker hub for an official image. Except you'ld need and official repository, getting one for FOSS project is quite easy. So if you're interested, tell me, I'll add it to the PR

Fare well :-)

