### PR TITLE
Search node schema in all possible sub schemas

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4453,7 +4453,12 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
   const nextPath = path.slice(1, path.length)
   const nextKey = path[0]
 
-  const possibleSchemas = currentSchema.oneOf || currentSchema.anyOf || currentSchema.allOf || [currentSchema]
+  let possibleSchemas = [currentSchema];
+  for (const subSchemas of [ currentSchema.oneOf, currentSchema.anyOf, currentSchema.allOf]) {
+    if (Array.isArray(subSchemas)) {
+      possibleSchemas = possibleSchemas.concat(subSchemas);
+    }
+  }
 
   for (const schema of possibleSchemas) {
     currentSchema = schema

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4453,10 +4453,10 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
   const nextPath = path.slice(1, path.length)
   const nextKey = path[0]
 
-  let possibleSchemas = [currentSchema];
-  for (const subSchemas of [ currentSchema.oneOf, currentSchema.anyOf, currentSchema.allOf]) {
+  let possibleSchemas = [currentSchema]
+  for (const subSchemas of [currentSchema.oneOf, currentSchema.anyOf, currentSchema.allOf]) {
     if (Array.isArray(subSchemas)) {
-      possibleSchemas = possibleSchemas.concat(subSchemas);
+      possibleSchemas = possibleSchemas.concat(subSchemas)
     }
   }
 

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -97,6 +97,44 @@ describe('Node', () => {
       assert.strictEqual(Node._findSchema(schema, {}, path), null)
     })
 
+    it('should find one of required properties', () => {
+      const schema = {
+        "properties": {
+          "company": {
+            "type": "string",
+            "enum": ["1", "2"]
+          },
+          "worker": {
+            "type": "string",
+            "enum": ["a", "b"]
+          },
+          "manager": {
+            "type": "string",
+            "enum": ["c", "d"]
+          },
+        },
+        "additionalProperties": false,
+        "oneOf": [
+          {
+            "required": ["worker"]
+          },
+          {
+            "required": ["manager"]
+          }
+        ]
+      };
+      let path = ['company']
+      assert.deepStrictEqual(Node._findSchema(schema, {}, path), {
+          "type": "string",
+          "enum": ["1", "2"]
+      });
+      path = ['worker']
+      assert.deepStrictEqual(Node._findSchema(schema, {}, path), {
+        "type": "string",
+        "enum": ["a", "b"]
+      })
+    })
+
     describe('with $ref', () => {
       it('should find a referenced schema', () => {
         const schema = {

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -99,39 +99,39 @@ describe('Node', () => {
 
     it('should find one of required properties', () => {
       const schema = {
-        "properties": {
-          "company": {
-            "type": "string",
-            "enum": ["1", "2"]
+        properties: {
+          company: {
+            type: 'string',
+            enum: ['1', '2']
           },
-          "worker": {
-            "type": "string",
-            "enum": ["a", "b"]
+          worker: {
+            type: 'string',
+            enum: ['a', 'b']
           },
-          "manager": {
-            "type": "string",
-            "enum": ["c", "d"]
-          },
+          manager: {
+            type: 'string',
+            enum: ['c', 'd']
+          }
         },
-        "additionalProperties": false,
-        "oneOf": [
+        additionalProperties: false,
+        oneOf: [
           {
-            "required": ["worker"]
+            required: ['worker']
           },
           {
-            "required": ["manager"]
+            required: ['manager']
           }
         ]
-      };
+      }
       let path = ['company']
       assert.deepStrictEqual(Node._findSchema(schema, {}, path), {
-          "type": "string",
-          "enum": ["1", "2"]
-      });
+        type: 'string',
+        enum: ['1', '2']
+      })
       path = ['worker']
       assert.deepStrictEqual(Node._findSchema(schema, {}, path), {
-        "type": "string",
-        "enum": ["a", "b"]
+        type: 'string',
+        enum: ['a', 'b']
       })
     })
 


### PR DESCRIPTION
Currently, `Node._findSchema` looks **either** in the root schema or **one of** `oneOf`, `anyOf` or `allOf` sub schemas. The correct behavior would be to look in all of them.

This should fix #1282 