### PR TITLE
Fixed relative URLs from becoming absolute during build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,6 +181,8 @@ gulp.task('bundle-minimalist', function (done) {
 
 // bundle css
 gulp.task('bundle-css', function (done) {
+  const concatOptions = { rebaseUrls: false }
+  const minifyOptions = { rebase: false }
   gulp
     .src(['src/scss/jsoneditor.scss'])
     .pipe(
@@ -188,10 +190,10 @@ gulp.task('bundle-css', function (done) {
         // importer: tildeImporter
       })
     )
-    .pipe(concatCss(NAME + '.css'))
+    .pipe(concatCss(NAME + '.css', concatOptions))
     .pipe(gulp.dest(DIST))
-    .pipe(concatCss(NAME + '.min.css'))
-    .pipe(minifyCSS())
+    .pipe(concatCss(NAME + '.min.css', concatOptions))
+    .pipe(minifyCSS(minifyOptions))
     .pipe(gulp.dest(DIST))
   done()
 })


### PR DESCRIPTION
This PR addresses the generated absolute image URLs mentioned in https://github.com/josdejong/jsoneditor/issues/675. The `gulp-concat-css` build would previously convert the paths in the `dist` folder to be relative. However, disabling the `rebaseUrls` option (which defaults to true) will prevent the URLs from being changed ([gulp-concat-css API](https://github.com/mariocasciaro/gulp-concat-css#examples)). 

Additionally, `gulp-clean-css` would still rebase the URLs with the above change, so a similar option had to disabled there too for relative URLs in the `.min.css` file ([gulp-clean-css options](https://github.com/clean-css/clean-css#constructor-options)).

Example of a relative URL in the `dist/jsoneditor.css` file:
```
.jsoneditor-contextmenu .jsoneditor-menu li button .jsoneditor-expand {
  position: absolute;
  top: 0;
  right: 0;
  width: 24px;
  height: 24px;
  padding: 0;
  margin: 0 4px 0 0;
  background-image: url("./img/jsoneditor-icons.svg");
  background-position: 0 -72px;
}
```

If there is anything else I should add please let me know!