### PR TITLE
Use noreferrer for window.open

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -2581,7 +2581,7 @@ export class Node {
             // if read-only, we use the regular click behavior of an anchor
             if (isUrl(this.value)) {
               event.preventDefault()
-              window.open(this.value, '_blank', 'noopener')
+              window.open(this.value, '_blank', 'noreferrer')
             }
           }
           break
@@ -2749,7 +2749,7 @@ export class Node {
       if (target === this.dom.value) {
         if (!this.editable.value || event.ctrlKey) {
           if (isUrl(this.value)) {
-            window.open(this.value, '_blank', 'noopener')
+            window.open(this.value, '_blank', 'noreferrer')
             handled = true
           }
         }

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -244,7 +244,7 @@ textmode.create = function (container, options = {}) {
         // TODO: this anchor falls below the margin of the content,
         // therefore the normal a.href does not work. We use a click event
         // for now, but this should be fixed.
-        window.open(poweredBy.href, poweredBy.target, 'noopener')
+        window.open(poweredBy.href, poweredBy.target, 'noreferrer')
       }
       this.menu.appendChild(poweredBy)
     }


### PR DESCRIPTION
#### Notes
- Using `noopener` without `noreferrer` is a security risk with a threat of Reverse Tabnabbing. 
- Changing the flag to `noreferrer` which [automatically sets](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#window_features) `noopener` as well. 

#### Testing
- No linting issues and all tests pass.