### PR TITLE
Add support for external validation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -210,7 +210,20 @@ Constructs a new JSONEditor.
     }
   }
   ```
-  
+
+- `{function} setValidationErrors(errors: ValidationError[])`
+  Set the validation errors from external sources. Available in all modes.
+
+  Typically the editor is embedded into an external site that might have its own validation scheme, this API is used to convey the errors from the external validation.
+
+  The `ValidationError` contains a `type`, `path`, and `message`.
+
+  Please note that this is different from `JSONEditor.onValidationError` as the trigger for the validation cannot be controlled for that.
+
+- `{function} clearValidationErrors()`
+  Clear the validation errors set by external sources. Available in all modes.
+
+  See `JSONEditor.setValidationErrors`
   
 - `{function} onCreateMenu(items, node)`
   

--- a/examples/25_external_validation.html
+++ b/examples/25_external_validation.html
@@ -1,0 +1,117 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>JSONEditor | External validation errors</title>
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    body {
+      width: 600px;
+      font: 11pt sans-serif;
+    }
+    #jsoneditor {
+      width: 100%;
+      height: 500px;
+    }
+
+  </style>
+</head>
+<body>
+<h1>Custom validation</h1>
+<p>
+  This example demonstrates how to set or clear errors from the external validation.
+  This mechanism is available in all modes.
+</p>
+
+<div id="jsoneditor"></div>
+
+<script>
+  const json = {
+    team: [
+      {
+        name: 'Joe',
+        age: 17
+      },
+      {
+        name: 'Sarah',
+        age: 13
+      },
+      {
+        name: 'Jack'
+      }
+    ]
+  }
+
+  const options = {
+    mode: 'tree',
+    modes: ['code', 'text', 'tree', 'preview'],
+    onValidate: function (json) {
+      // rules:
+      // - team, names, and ages must be filled in and be of correct type
+      // - a team must have 4 members
+      // - at lease one member of the team must be adult
+      const errors = []
+
+      if (json && Array.isArray(json.team)) {
+        // check whether each team member has name and age filled in correctly
+        json.team.forEach(function (member, index) {
+          if (typeof member !== 'object') {
+            errors.push({path: ['team', index], message: 'Member must be an object with properties "name" and "age"'})
+          }
+
+          if ('name' in member) {
+            if (typeof member.name !== 'string') {
+              errors.push({path: ['team', index, 'name'], message: 'Name must be a string'})
+            }
+          } else {
+            errors.push({path: ['team', index], message: 'Required property "name"" missing'})
+          }
+
+          if ('age' in member) {
+            if (typeof member.age !== 'number') {
+              errors.push({path: ['team', index, 'age'], message: 'Age must be a number'})
+            }
+          } else {
+            errors.push({path: ['team', index], message: 'Required property "age" missing'})
+          }
+        })
+
+        // check whether the team consists of exactly four members
+        if (json.team.length !== 4) {
+          errors.push({path: ['team'], message: 'A team must have 4 members'})
+        }
+
+        // check whether there is at least one adult member in the team
+        const adults = json.team.filter(function (member) {
+          return member ? member.age >= 18 : false
+        })
+        if (adults.length === 0) {
+          errors.push({path: ['team'], message: 'A team must have at least one adult person (age >= 18)'})
+        }
+      } else {
+        errors.push({path: [], message: 'Required property "team" missing or not an Array'})
+      }
+
+      return errors
+    }
+  }
+
+  function sleep(ms) {
+     return new Promise( resolver => setTimeout(resolver, ms));
+  };
+
+  // create the editor
+  const container = document.getElementById('jsoneditor')
+  const editor = new JSONEditor(container, options, json)
+
+  // Set Errors based on external validation: e.g. on Save
+  editor.setValidationErrors([{path: ['team', 1, 'name'], message: 'Unknown name "Sarah"'}]);
+  // After 5 secs, clear the errors: e.g. Fix and then Save
+  sleep(5000).then(() => editor.clearValidationErrors());
+</script>
+</body>
+</html>


### PR DESCRIPTION
In some usecases that need control on when a validation is triggered
there is no way to render the resutls of that validation and custom
validation handler cannot be used as that will be called for every
change. E.g., Save/Cancel based validation outside the editor.

Add two new APIs (set/clear)ValidatonErrors to update the results of the
external validation, these errors will be merged with other validation
errors and rendered all together.

Add an example to demonstrate the usecase and document the APIs.