### PR TITLE
fix: verify object prototype before define 'remove' property in it

### DIFF
--- a/src/js/polyfills.js
+++ b/src/js/polyfills.js
@@ -3,17 +3,19 @@ if (typeof Element !== 'undefined') {
   // Polyfill for array remove
   (() => {
     function polyfill (item) {
-      if ('remove' in item) {
-        return
-      }
-      Object.defineProperty(item, 'remove', {
-        configurable: true,
-        enumerable: true,
-        writable: true,
-        value: function remove () {
-          if (this.parentNode !== undefined) { this.parentNode.removeChild(this) }
+      if (typeof item !== 'undefined') {
+        if ('remove' in item) {
+          return
         }
-      })
+        Object.defineProperty(item, 'remove', {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: function remove () {
+            if (this.parentNode !== undefined) { this.parentNode.removeChild(this) }
+          }
+        })
+      }
     }
 
     if (typeof window.Element !== 'undefined') { polyfill(window.Element.prototype) }


### PR DESCRIPTION
Before define 'remove' property in the item's prototype, we need to check whether item is undefined or not.
If we don't check item, it could lead to an error like:
``Cannot use 'in' operator to search for 'remove' in undefined ``
For example, window.DocumentType.prototype can be undefined in some rare environment.