### PR TITLE
Feature/on node name

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -126,7 +126,7 @@ Constructs a new JSONEditor.
   Set a callback function triggered right after the mode is changed by the user. Only applicable when
   the mode can be changed by the user (i.e. when option `modes` is set).
 
-- `{function} onNodeName({ path, type, size })`
+- `{function} onNodeName({ path, type, size, value })`
 
   Customize the name of object and array nodes. By default the names are brackets with the number of childs inside,
   like `{5}` and `[32]`. The number inside can be customized. using `onNodeName`.
@@ -137,7 +137,8 @@ Constructs a new JSONEditor.
   {
     path: string[],
     type: 'object' | 'array',
-    size: number
+    size: number,
+    value: object
   }
   ```
 

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4064,7 +4064,8 @@ export class Node {
           nodeName = this.editor.options.onNodeName({
             path: this.getPath(),
             size: count,
-            type: this.type
+            type: this.type,
+            value: this.getValue()
           })
         } catch (err) {
           console.error('Error in onNodeName callback: ', err)

--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4065,7 +4065,7 @@ export class Node {
             path: this.getPath(),
             size: count,
             type: this.type,
-            value: this.getValue()
+            value: this.value
           })
         } catch (err) {
           console.error('Error in onNodeName callback: ', err)


### PR DESCRIPTION
This is an alternative implementation of what was requested in PR #839 
which supports the inclusion of access to the value of the node applicable to the event.
(also updated the documentation too)