### PR TITLE
Ignore unknown format when schema compilation and always pass validation

### DIFF
--- a/src/js/JSONEditor.js
+++ b/src/js/JSONEditor.js
@@ -357,7 +357,8 @@ JSONEditor.prototype.setSchema = function (schema, schemaRefs) {
           allErrors: true,
           verbose: true,
           schemaId: 'auto',
-          $data: true
+          $data: true,
+          unknownFormats:'ignore'
         })
 
         // support both draft-04 and draft-06 alongside the latest draft-07


### PR DESCRIPTION
Hi @josdejong,
Currentlty more and more customized format are used in JSON schema, some of them are not  supported by AJV 6.12.6. 
When we're using these schemas, it will report error like:
Unknown format 'unit16' is used in schema validation in console.
And then the JSONEditor cannot work anymore.
I do notice there're several similar cases, I guess the straight solution is to remove these formats in the schema file. Can we directly add option {unknownFormats: 'ignore'} when we instantiate the AJV object?

Or we can make it configurable?

REF: https://github.com/ajv-validator/ajv/tree/v6.12.6#options

BR/Lei