### PR TITLE
Control default behaviour of error table through options

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -408,6 +408,11 @@ Constructs a new JSONEditor.
 
   Adds status bar to the bottom of the editor - the status bar shows the cursor position and a count of the selected characters. `true` by default. Only applicable when `mode` is 'code', 'text', or 'preview'.
 
+- `{boolean} | {Array} showErrorTable`
+
+  Automatically expand error table above the status bar on error or validation error if `mode` matches an array item. Alternatively used as a boolean value.
+  `mode` is `['text', 'preview']` by default.
+
 - `{function} onTextSelectionChange(start, end, text)`
 
   Set a callback function triggered when a text is selected in the JSONEditor.

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -50,7 +50,7 @@ textmode.create = function (container, options = {}) {
   options.enableTransform = options.enableTransform !== false
   options.createQuery = options.createQuery || createQuery
   options.executeQuery = options.executeQuery || executeQuery
-
+  options.errorTableVisible = options.errorTableVisible
   this.options = options
 
   // indentation
@@ -327,7 +327,7 @@ textmode.create = function (container, options = {}) {
   this._updateHistoryButtons()
 
   this.errorTable = new ErrorTable({
-    errorTableVisible: this.mode === 'text',
+    errorTableVisible: this.options.errorTableVisible,
     onToggleVisibility: function () {
       me._validateAndCatch()
     },

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -51,6 +51,7 @@ textmode.create = function (container, options = {}) {
   options.createQuery = options.createQuery || createQuery
   options.executeQuery = options.executeQuery || executeQuery
   options.errorTableVisible = options.errorTableVisible
+  options.showErrorTable = options.showErrorTable || ['text'] 
   this.options = options
 
   // indentation
@@ -327,7 +328,7 @@ textmode.create = function (container, options = {}) {
   this._updateHistoryButtons()
 
   this.errorTable = new ErrorTable({
-    errorTableVisible: this.options.errorTableVisible,
+    errorTableVisible: this.options.showErrorTable.includes(this.mode),
     onToggleVisibility: function () {
       me._validateAndCatch()
     },

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -50,7 +50,7 @@ textmode.create = function (container, options = {}) {
   options.enableTransform = options.enableTransform !== false
   options.createQuery = options.createQuery || createQuery
   options.executeQuery = options.executeQuery || executeQuery
-  options.showErrorTable = options.showErrorTable || ['text'] 
+  options.showErrorTable = options.showErrorTable || ['text', 'preview'] 
   this.options = options
 
   // indentation

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -328,7 +328,7 @@ textmode.create = function (container, options = {}) {
   this._updateHistoryButtons()
 
   this.errorTable = new ErrorTable({
-    errorTableVisible: this.options.showErrorTable.includes(this.mode),
+    errorTableVisible: Array.isArray(this.options.showErrorTable) ? this.options.showErrorTable.includes(this.mode) : this.options.showErrorTable === true,
     onToggleVisibility: function () {
       me._validateAndCatch()
     },

--- a/src/js/textmode.js
+++ b/src/js/textmode.js
@@ -50,7 +50,6 @@ textmode.create = function (container, options = {}) {
   options.enableTransform = options.enableTransform !== false
   options.createQuery = options.createQuery || createQuery
   options.executeQuery = options.executeQuery || executeQuery
-  options.errorTableVisible = options.errorTableVisible
   options.showErrorTable = options.showErrorTable || ['text'] 
   this.options = options
 


### PR DESCRIPTION
Solves [Display error table through options if mode is other than text](https://github.com/josdejong/jsoneditor/issues/1496)