### PR TITLE
Fix source map paths in Uglify configuration

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,7 @@ const compilerMinimalist = webpack({
 
 function minify (name) {
   const code = String(fs.readFileSync(DIST + '/' + name + '.js'))
-  const result = uglify.minify(code, {
+  const result = uglify.minify({ [name + '.js']: code }, {
     sourceMap: {
       url: name + '.map'
     },


### PR DESCRIPTION
Source maps were written with `"0"` as the source filename.  This could result in errors similar to the following in Webpack (depending on the Webpack configuration):

```
WARNING in ../../node_modules/jsoneditor/dist/jsoneditor.min.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/josh/app/node_modules/jsoneditor/dist/0' file: Error: ENOENT: no such file or directory, open '/Users/josh/app/node_modules/jsoneditor/dist/0'
```

Uglify configuration based on https://github.com/mishoo/UglifyJS#api-reference.