### PR TITLE
[(develop)] fixed parseString when it trimming zero in the beggining

### DIFF
--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1131,6 +1131,10 @@ export function parseString (str) {
     return false
   }
 
+  if (str.length > 1 && str.charAt(0) === '0') {
+    return str;
+  }
+
   const num = Number(str) // will nicely fail with '123ab'
   const numFloat = parseFloat(str) // will nicely fail with '  '
   if (!isNaN(num) && !isNaN(numFloat)) {

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1132,7 +1132,7 @@ export function parseString (str) {
   }
 
   if (/^0\d+$/.test(str)) { // to treat '001' as a string
-    return str;
+    return str
   }
 
   const num = Number(str) // will nicely fail with '123ab'

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1131,7 +1131,7 @@ export function parseString (str) {
     return false
   }
 
-  if (str.length > 1 && str.charAt(0) === '0') {
+  if (/^0\d+$/.test(str)) { // to treat '001' as a string
     return str;
   }
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -315,6 +315,7 @@ describe('util', () => {
     assert.strictEqual(parseString('false'), false)
     assert.strictEqual(parseString('+1'), 1)
     assert.strictEqual(parseString('01'), '01')
+    assert.strictEqual(parseString('001'), '001')
     assert.strictEqual(parseString(' '), ' ')
     assert.strictEqual(parseString(''), '')
     assert.strictEqual(parseString('"foo"'), '"foo"')

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -314,6 +314,7 @@ describe('util', () => {
     assert.strictEqual(parseString('true'), true)
     assert.strictEqual(parseString('false'), false)
     assert.strictEqual(parseString('+1'), 1)
+    assert.strictEqual(parseString('01'), '01')
     assert.strictEqual(parseString(' '), ' ')
     assert.strictEqual(parseString(''), '')
     assert.strictEqual(parseString('"foo"'), '"foo"')

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -316,6 +316,8 @@ describe('util', () => {
     assert.strictEqual(parseString('+1'), 1)
     assert.strictEqual(parseString('01'), '01')
     assert.strictEqual(parseString('001'), '001')
+    assert.strictEqual(parseString('0.3'), 0.3)
+    assert.strictEqual(parseString('0e3'), 0)
     assert.strictEqual(parseString(' '), ' ')
     assert.strictEqual(parseString(''), '')
     assert.strictEqual(parseString('"foo"'), '"foo"')


### PR DESCRIPTION
Hello,
I have a problem when I add new elements to an array, and even when I provide schema validation that only strings are allowed, JsonEditor always removes 0 in front of the number, after some investigation I found that `parseString` is casting values like **0**102031234 to number and removes zero in front and making 102031234, that is absolutely wrong.  (this number is actually example of CPR number in Denmark, it is like your passport number)
Please, take into consideration my PR.

P.S. @josdejong great tool, thank you!