### PR TITLE
Fix reduce bug

### DIFF
--- a/src/js/SchemaTextCompleter.js
+++ b/src/js/SchemaTextCompleter.js
@@ -178,7 +178,7 @@ export class SchemaTextCompleter {
                 }
               }
               return last
-            })
+            }, null)
             if (typeof option === 'string') {
               if (currentSuggestions[option]?.refs?.length) {
                 const mergedSuggestions = {}


### PR DESCRIPTION
Fix the bug where we get this uncaught error:

> TypeError: reduce of empty array with no initial value

I'm not sure yet how to build construct a unit test to demonstrate the issue, but it is occurring for our JSON schema. At this line, when `currentSuggestions` is an empty object `{}`, `Object.keys` is an empty array, and therefore without having an initial value for the call to `.reduce(...)` it'll bomb out.
