### PR TITLE
Fix test suite in Node 22

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -13,7 +13,9 @@ function setUpTestEnvironment (locale) {
   const dom = new JSDOM('...')
   global.window = dom.window
   global.document = dom.window.document
-  global.navigator = dom.window.navigator
+  if (typeof global.navigator === 'undefined') {
+    global.navigator = dom.window.navigator
+  }
 
   // JSDom has no setter defined for navigator.language, so defineProperty is necessary in order to override it
   Object.defineProperty(navigator, 'language', { value: locale })


### PR DESCRIPTION
Node now provides a `navigator` global (https://nodejs.org/api/globals.html#navigator_1), which could cause JSONEditor's test suite to fail with the following error.

```
 Exception during run: TypeError: Cannot set property navigator of #<Object> which has only a getter
    at setUpTestEnvironment (jsoneditor/test/setup.js:16:19)
    at Object.<anonymous> (jsoneditor/test/setup.js:22:1)
```