### PR TITLE
Handle `true` property value

### DIFF
--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -198,6 +198,40 @@ describe('Node', () => {
       })
     })
 
+    // https://json-schema.org/understanding-json-schema/reference/object#extending
+    it('works with extending schemas', () => {
+      const schema = {
+        properties: {
+          name: true,
+          manager: {
+            type: 'string',
+            enum: ['c', 'd']
+          }
+        },
+        additionalProperties: false,
+        allOf: [
+          {
+            properties: {
+              name: {
+                type: 'string',
+                enum: ['a', 'b']
+              }
+            }
+          }
+        ]
+      }
+      let path = ['name']
+      assert.deepStrictEqual(Node._findSchema(schema, {}, path), {
+        type: 'string',
+        enum: ['a', 'b']
+      })
+      path = ['manager']
+      assert.deepStrictEqual(Node._findSchema(schema, {}, path), {
+        type: 'string',
+        enum: ['c', 'd']
+      })
+    })
+
     describe('with $ref', () => {
       it('should find a referenced schema', () => {
         const schema = {
@@ -401,6 +435,7 @@ describe('Node', () => {
         assert.notStrictEqual(Node._findSchema(schema, { 'definitions.json': definitions }, path), foundSchema)
       })
     })
+
     describe('with pattern properties', () => {
       it('should find schema', () => {
         const schema = {


### PR DESCRIPTION
A JSON Schema of `true` means to allow anything. It can be useful when extending closed schemas; see https://json-schema.org/understanding-json-schema/reference/object#extending.

Fixes #1643