### PR TITLE
Minimal fix for `true` property handling

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -4508,7 +4508,7 @@ Node._findSchema = (topLevelSchema, schemaRefs, path, currentSchema = topLevelSc
   for (const schema of possibleSchemas) {
     currentSchema = schema
 
-    if ('$ref' in currentSchema && typeof currentSchema.$ref === 'string') {
+    if (typeof currentSchema === 'object' && '$ref' in currentSchema && typeof currentSchema.$ref === 'string') {
       const ref = currentSchema.$ref
       if (ref in schemaRefs) {
         currentSchema = schemaRefs[ref]

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -198,6 +198,38 @@ describe('Node', () => {
       })
     })
 
+    // https://json-schema.org/understanding-json-schema/reference/object#extending
+    it('works with extending schemas', () => {
+      const schema = {
+        properties: {
+          name: true,
+          manager: {
+            type: 'string',
+            enum: ['c', 'd']
+          }
+        },
+        additionalProperties: false,
+        allOf: [
+          {
+            properties: {
+              name: {
+                type: 'string',
+                enum: ['a', 'b']
+              }
+            }
+          }
+        ]
+      }
+      let path = ['name']
+      // Specifics aren't resolved due to limits of allOf support
+      assert(Node._findSchema(schema, {}, path))
+      path = ['manager']
+      assert.deepStrictEqual(Node._findSchema(schema, {}, path), {
+        type: 'string',
+        enum: ['c', 'd']
+      })
+    })
+
     describe('with $ref', () => {
       it('should find a referenced schema', () => {
         const schema = {
@@ -401,6 +433,7 @@ describe('Node', () => {
         assert.notStrictEqual(Node._findSchema(schema, { 'definitions.json': definitions }, path), foundSchema)
       })
     })
+
     describe('with pattern properties', () => {
       it('should find schema', () => {
         const schema = {


### PR DESCRIPTION
If #1644 is a more invasive change than is desired, this more minimal fix prevents runtime errors but makes less of an effort to resolve affected properties.

Fixes #1643