### PR TITLE
Add support for object arrays with separate `text` and `value`

### DIFF
--- a/examples/28_autocomplete_text_value_objects.html
+++ b/examples/28_autocomplete_text_value_objects.html
@@ -1,0 +1,166 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>JSONEditor | Auto Complete with Text/Value Objects</title>
+
+  <link href="../dist/jsoneditor.css" rel="stylesheet" type="text/css">
+  <script src="../dist/jsoneditor.js"></script>
+
+  <style type="text/css">
+    .editor-container {
+      width: 500px;
+      height: 400px;
+      margin-bottom: 30px;
+    }
+
+    p {
+      width: 800px;
+      font-family: "DejaVu Sans", sans-serif;
+      margin-bottom: 20px;
+    }
+
+    h3 {
+      font-family: "DejaVu Sans", sans-serif;
+      color: #333;
+      margin-top: 30px;
+      margin-bottom: 10px;
+    }
+
+    .demo-section {
+      margin-bottom: 40px;
+      padding: 20px;
+      border: 1px solid #ddd;
+      border-radius: 5px;
+      background-color: #f9f9f9;
+    }
+
+    .search-info {
+      background-color: #e8f4fd;
+      padding: 10px;
+      border-left: 4px solid #2196F3;
+      margin: 10px 0;
+      font-size: 14px;
+    }
+  </style>
+
+</head>
+<body>
+<h1>JSONEditor - Enhanced Autocomplete with Text/Value Objects</h1>
+
+<p>
+  This example demonstrates the enhanced autocomplete functionality that supports both traditional string arrays 
+  and new object arrays with separate <code>text</code> and <code>value</code> properties. The autocomplete can 
+  search within both the display text and the underlying value.
+</p>
+
+<div class="demo-section">
+  <h3>1. Traditional String Array Autocomplete (Backward Compatible)</h3>
+  <p>Original functionality with simple string arrays:</p>
+  <div class="search-info">
+    <strong>Available options:</strong> 'apple', 'cranberry', 'raspberry', 'pie', 'mango', 'mandarine', 'melon', 'appleton'<br>
+    <strong>Search:</strong> Type any part of the fruit names to see suggestions.
+  </div>
+  <div id="jsoneditor1" class="editor-container"></div>
+</div>
+
+<div class="demo-section">
+  <h3>2. Enhanced Object Array Autocomplete (New Feature)</h3>
+  <p>New functionality using objects with <code>text</code> (display) and <code>value</code> (actual value) properties:</p>
+  <div class="search-info">
+    <strong>Search by Company Name:</strong> Try typing "Apple", "Microsoft", "Google", etc.<br>
+    <strong>Search by Stock Symbol:</strong> Try typing "AAPL", "MSFT", "GOOGL", etc.<br>
+    <strong>Result:</strong> The dropdown shows company names, but the selected value will be the stock symbol.
+  </div>
+  <div id="jsoneditor2" class="editor-container"></div>
+</div>
+
+<div class="demo-section">
+  <h3>3. Mixed Content Example</h3>
+  <p>Countries with multiple searchable fields (name, code, and capital):</p>
+  <div class="search-info">
+    <strong>Search by Country:</strong> "United States", "Germany", "Japan"<br>
+    <strong>Search by Code:</strong> "US", "DE", "JP"<br>
+    <strong>Search by Capital:</strong> "Washington", "Berlin", "Tokyo"<br>
+    <strong>Result:</strong> Displays country name, returns country code as value.
+  </div>
+  <div id="jsoneditor3" class="editor-container"></div>
+</div>
+
+<script>
+  // Example 1: Traditional string array (backward compatible)
+  const container1 = document.getElementById('jsoneditor1')
+  const options1 = {
+    autocomplete: {
+      getOptions: function () {
+        return ['apple', 'cranberry', 'raspberry', 'pie', 'mango', 'mandarine', 'melon', 'appleton'];
+      }
+    }
+  }
+  const json1 = {
+    'fruits': ['apple', 'mango'],
+    'favorite': 'cranberry',
+    'description': 'Traditional string array autocomplete'
+  }
+  const editor1 = new JSONEditor(container1, options1, json1)
+
+  // Example 2: Object array with text/value properties
+  const container2 = document.getElementById('jsoneditor2')
+  const options2 = {
+    autocomplete: {
+      getOptions: function () {
+        return [
+          { text: 'Apple Inc.', value: 'AAPL' },
+          { text: 'Microsoft Corporation', value: 'MSFT' },
+          { text: 'Alphabet Inc. (Google)', value: 'GOOGL' },
+          { text: 'Amazon.com Inc.', value: 'AMZN' },
+          { text: 'Tesla Inc.', value: 'TSLA' },
+          { text: 'Meta Platforms Inc. (Facebook)', value: 'META' },
+          { text: 'NVIDIA Corporation', value: 'NVDA' },
+          { text: 'Netflix Inc.', value: 'NFLX' },
+          { text: 'PayPal Holdings Inc.', value: 'PYPL' },
+          { text: 'Adobe Inc.', value: 'ADBE' }
+        ];
+      }
+    }
+  }
+  const json2 = {
+    'portfolio': ['AAPL', 'GOOGL'],
+    'watchlist': ['TSLA', 'META'],
+    'favorite_stock': 'MSFT',
+    'description': 'Search by company name or stock symbol - value stored is the symbol'
+  }
+  const editor2 = new JSONEditor(container2, options2, json2)
+
+  // Example 3: More complex objects with multiple searchable fields
+  const container3 = document.getElementById('jsoneditor3')
+  const options3 = {
+    autocomplete: {
+      getOptions: function () {
+        return [
+          { text: 'United States', value: 'US' },
+          { text: 'United Kingdom', value: 'GB' },
+          { text: 'Germany', value: 'DE' },
+          { text: 'France', value: 'FR' },
+          { text: 'Japan', value: 'JP' },
+          { text: 'Australia', value: 'AU' },
+          { text: 'Canada', value: 'CA' },
+          { text: 'Brazil', value: 'BR' },
+          { text: 'India', value: 'IN' },
+          { text: 'China', value: 'CN' }
+        ];
+      }
+    }
+  }
+  const json3 = {
+    'user_countries': ['US', 'DE'],
+    'origin_country': 'JP',
+    'shipping_countries': ['US', 'CA', 'GB'],
+    'description': 'Search by country name or code - value stored is the country code'
+  }
+  const editor3 = new JSONEditor(container3, options3, json3)
+</script>
+
+</body>
+</html> 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsoneditor",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "main": "./dist/jsoneditor.min.js",
   "description": "A web-based tool to view, edit, format, and validate JSON",
   "tags": [


### PR DESCRIPTION
- Add support for object arrays with separate `text` and `value` properties
- Enable search functionality within both text and value fields
- Maintain full backward compatibility with existing string arrays
- Add helper functions: getOptionText(), getOptionValue(), getSearchableContent()
- Update filtering logic to handle both string and object formats
- Create comprehensive example (28_autocomplete_text_value_objects.html)
- Bump version to 10.3.0