### PR TITLE
Change some class names in the darktheme.css example file

### DIFF
--- a/examples/css/darktheme.css
+++ b/examples/css/darktheme.css
@@ -34,12 +34,12 @@ div.jsoneditor-value.jsoneditor-highlight {
   border-color: #808080;
 }
 
-div.jsoneditor-field.highlight-active,
-div.jsoneditor-field.highlight-active:focus,
-div.jsoneditor-field.highlight-active:hover,
-div.jsoneditor-value.highlight-active,
-div.jsoneditor-value.highlight-active:focus,
-div.jsoneditor-value.highlight-active:hover {
+div.jsoneditor-field.jsoneditor-highlight-active,
+div.jsoneditor-field.jsoneditor-highlight-active:focus,
+div.jsoneditor-field.jsoneditor-highlight-active:hover,
+div.jsoneditor-value.jsoneditor-highlight-active,
+div.jsoneditor-value.jsoneditor-highlight-active:focus,
+div.jsoneditor-value.jsoneditor-highlight-active:hover {
   background-color: #b1b1b1;
   border-color: #b1b1b1;
 }


### PR DESCRIPTION
Hi :wave: 
Thanks for such a great tool :fire: 

I tried to apply styles from the `examples/css/darktheme.css` file, and faced with some highlighting issues when using the search functionality :crying_cat_face: 
These code changes helped me to solve them :white_check_mark: 

Unfortunately, I don't have time to properly verify that these changes are correct, :see_no_evil: 
but probably I'm not mistaking, and there indeed are typos :thinking: 
You may just close this PR if I missed something :monocle_face: 

Best regards :raised_hands: 
