### PR TITLE
fix: associate transform preview with its visible label

### DIFF
--- a/src/js/showTransformModal.js
+++ b/src/js/showTransformModal.js
@@ -98,7 +98,7 @@ export function showTransformModal (
       '            spellcheck="false"' +
       '            title="' + translate('transformQueryTitle') + '">[*]</textarea>' +
       '</div>' +
-      '<div class="jsoneditor-jmespath-label">' + translate('transformPreviewLabel') + ' </div>' +
+      '<div class="jsoneditor-jmespath-label"><label for="preview">' + translate('transformPreviewLabel') + ' </label></div>' +
       '<div class="jsoneditor-jmespath-block">' +
       '  <textarea id="preview" ' +
       '      class="jsoneditor-transform-preview"' +
@@ -185,8 +185,8 @@ export function showTransformModal (
 
       elem.querySelector('.pico-modal-contents').onclick = event => {
         // prevent the first clear button (in any select box) from getting
-        // focus when clicking anywhere in the modal. Only allow clicking links.
-        if (event.target.nodeName !== 'A') {
+        // focus when clicking anywhere in the modal. Allow links and labels.
+        if (event.target.nodeName !== 'A' && event.target.nodeName !== 'LABEL') {
           event.preventDefault()
         }
       }

--- a/test/showTransformModal.test.js
+++ b/test/showTransformModal.test.js
@@ -1,0 +1,45 @@
+import assert from 'assert'
+import './setup'
+import { showTransformModal } from '../src/js/showTransformModal'
+import { setLanguage, translate } from '../src/js/i18n'
+
+describe('showTransformModal', () => {
+  let container
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    container.querySelector('.pico-close').click()
+    container.remove()
+    setLanguage('en')
+  })
+
+  for (const language of ['en', 'fr-FR']) {
+    it(`should associate the preview with its visible label in ${language}`, async () => {
+      setLanguage(language)
+      showTransformModal({
+        container,
+        json: [{ name: 'Alice' }],
+        createQuery: () => '[*]',
+        executeQuery: json => json,
+        onTransform: () => {}
+      })
+      await new Promise(resolve => setTimeout(resolve, 350))
+
+      const preview = container.querySelector('#preview')
+      assert.strictEqual(preview.labels.length, 1)
+      const label = preview.labels[0]
+      assert.strictEqual(label.textContent.trim(), translate('transformPreviewLabel'))
+      assert.strictEqual(label.control, preview)
+      assert.strictEqual(preview.readOnly, true)
+      assert.deepStrictEqual(JSON.parse(preview.value), [{ name: 'Alice' }])
+
+      const click = new window.MouseEvent('click', { bubbles: true, cancelable: true })
+      label.dispatchEvent(click)
+      assert.strictEqual(click.defaultPrevented, false)
+    })
+  }
+})


### PR DESCRIPTION
Fixes #1573.

The Transform dialog renders "Preview" as an unassociated div, leaving its read-only textarea without an accessible name. Wrap the existing translated text in a native label targeting the preview. Allow label activation through the dialog's click handler so clicking "Preview" focuses the textarea, while preserving the existing layout.

Validation:
- Added DOM regression tests for English and French label association, uncancelled label activation, and unchanged read-only preview output. The association assertion failed on the original source.
- `npm run build-and-test` passes: build, all 71 tests, and StandardJS lint.
- Verified the built editor in Chromium: the accessibility tree names the textarea "Preview", and clicking its visible label focuses it with the expected JSON content.

Implemented and validated with OpenAI Codex assistance. No screen-reader software test was performed.
