### PR TITLE
fix: ignore delayed field changes on removed nodes

### DIFF
--- a/src/js/Node.js
+++ b/src/js/Node.js
@@ -1629,6 +1629,11 @@ export class Node {
    * @private
    */
   _onChangeField () {
+    // A data update can remove this node while its field change is debounced.
+    if (!this.parent) {
+      return
+    }
+
     // get current selection, then override the range such that we can select
     // the added/removed text on undo/redo
     const oldSelection = this.editor.getDomSelection()

--- a/test/Node.test.js
+++ b/test/Node.test.js
@@ -3,6 +3,47 @@ import './setup'
 import { Node } from '../src/js/Node'
 
 describe('Node', () => {
+  describe('_onChangeField', () => {
+    it('should ignore a debounced field change after the node is removed', async () => {
+      const actions = []
+      const editor = {
+        options: {},
+        getDomSelection: () => ({}),
+        _onAction: (...args) => actions.push(args)
+      }
+      const parent = new Node(editor, { value: { hello: 'world' } })
+      const child = parent.childs[0]
+      child.field = 'renamed'
+      child._debouncedOnChangeField()
+      parent.removeChild(child, false)
+
+      await new Promise(resolve => setTimeout(resolve, child.DEBOUNCE_INTERVAL + 50))
+
+      assert.strictEqual(child.parent, null)
+      assert.deepStrictEqual(actions, [])
+    })
+
+    it('should still record a field change for an attached node', () => {
+      const actions = []
+      const editor = {
+        options: {},
+        getDomSelection: () => ({}),
+        _onAction: (...args) => actions.push(args)
+      }
+      const parent = new Node(editor, { value: { hello: 'world' } })
+      const child = parent.childs[0]
+      child.field = 'renamed'
+      child._onChangeField()
+
+      assert.strictEqual(actions.length, 1)
+      assert.strictEqual(actions[0][0], 'editField')
+      assert.strictEqual(actions[0][1].oldValue, 'hello')
+      assert.strictEqual(actions[0][1].newValue, 'renamed')
+      assert.deepStrictEqual(actions[0][1].parentPath, [])
+      assert.strictEqual(child.previousField, 'renamed')
+    })
+  })
+
   describe('_findSchema', () => {
     it('should find schema', () => {
       const schema = {


### PR DESCRIPTION
Renaming an object key and immediately calling `editor.update()` with replacement data can remove that node before its debounced field-change callback runs. The callback then dereferences `this.parent.getInternalPath()` with a null parent and throws.

Ignore the delayed field change when the node no longer has a parent, following the approach suggested in #1498. A regression test schedules the real debounce and removes the node before it fires; a second test confirms attached-node edits still record their action and previous field value.

Validation: `npm run build-and-test` passes (build, 71 tests, StandardJS lint). Actual Chromium reproduction dispatches a key-edit input event and immediately calls `editor.update({ replacement: 42 })`: original bundle throws the reported null-parent error; rebuilt bundle produces no page error and preserves the replacement data. Diff check passes. Prepared with AI assistance and locally verified.

Fixes #1498.
